### PR TITLE
RuleSet::addRule() insert position support.

### DIFF
--- a/lib/Sabberworm/CSS/RuleSet/RuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/RuleSet.php
@@ -17,12 +17,22 @@ abstract class RuleSet implements Renderable {
 		$this->aRules = array();
 	}
 
-	public function addRule(Rule $oRule) {
+	public function addRule(Rule $oRule, Rule $oSibling = null, /* boolean */ $bPrepend = false) {
 		$sRule = $oRule->getRule();
 		if(!isset($this->aRules[$sRule])) {
 			$this->aRules[$sRule] = array();
 		}
-		$this->aRules[$sRule][] = $oRule;
+
+		$iPosition = $bPrepend ? 0 : count($this->aRules[$sRule]);
+
+		if ($oSibling !== null) {
+			$iSiblingPos = array_search($oSibling, $this->aRules[$sRule], true);
+			if ($iSiblingPos !== false) {
+				$iPosition = $bPrepend ? $iSiblingPos : $iSiblingPos + 1;
+			}
+		}
+
+		array_splice($this->aRules[$sRule], $iPosition, 0, array($oRule));
 	}
 
 	/**


### PR DESCRIPTION
I'm currently using this lib to auto-prefix css rules for a wider browser support without the need to manually add all those rules. This requires me to add the new prefixed rules before the unprefixed one. I Made some additions to allow you to specify the exact location where the final Rule should be:
