### PR TITLE
Increase performance up to 15000%

### DIFF
--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -583,8 +583,14 @@ class Parser {
 	}
 
 	private function substr($iStart, $iLength) {
+		if ($iLength < 0) {
+			$iLength = $this->iLength - $iStart + $iLength;
+		}
+		if ($iStart + $iLength > $this->iLength) {
+			$iLength = $this->iLength - $iStart;
+		}
 		$out = '';
-		while ($iLength > 0 && $iStart < $this->iLength) {
+		while ($iLength > 0) {
 			$out .= $this->aText[$iStart];
 			$iStart++;
 			$iLength--;

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -490,7 +490,6 @@ class Parser {
 		if ($iOffset >= $this->iLength) {
 			return '';
 		}
-		$iLength = min($iLength, $this->iLength-$iOffset);
 		$out = $this->substr($iOffset, $iLength);
 		return $out;
 	}
@@ -585,7 +584,7 @@ class Parser {
 
 	private function substr($iStart, $iLength) {
 		$out = '';
-		while ($iLength > 0) {
+		while ($iLength > 0 && $iStart < $this->iLength) {
 			$out .= $this->aText[$iStart];
 			$iStart++;
 			$iLength--;

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -31,7 +31,6 @@ class Parser {
 	private $oParserSettings;
 	private $sCharset;
 	private $iLength;
-	private $peekCache = null;
 	private $blockRules;
 	private $aSizeUnits;
 
@@ -290,7 +289,6 @@ class Parser {
 						// We need to “unfind” the matches to the end of the ruleSet as this will be matched later
 						if($this->streql(substr($sConsume, -1), '}')) {
 							--$this->iCurrentPosition;
-							$this->peekCache = null;
 						} else {
 							$this->consumeWhiteSpace();
 							while ($this->comes(';')) {
@@ -488,19 +486,12 @@ class Parser {
 	}
 
 	private function peek($iLength = 1, $iOffset = 0) {
-		if (($peek = (!$iOffset && ($iLength === 1))) &&
-			!is_null($this->peekCache)) {
-			return $this->peekCache;
-		}
 		$iOffset += $this->iCurrentPosition;
 		if ($iOffset >= $this->iLength) {
 			return '';
 		}
 		$iLength = min($iLength, $this->iLength-$iOffset);
 		$out = $this->substr($iOffset, $iLength);
-		if ($peek) {
-			$this->peekCache = $out;
-		}
 		return $out;
 	}
 
@@ -511,7 +502,6 @@ class Parser {
 				throw new UnexpectedTokenException($mValue, $this->peek(max($iLength, 5)));
 			}
 			$this->iCurrentPosition += $this->strlen($mValue);
-			$this->peekCache = null;
 			return $mValue;
 		} else {
 			if ($this->iCurrentPosition + $mValue > $this->iLength) {
@@ -519,7 +509,6 @@ class Parser {
 			}
 			$sResult = $this->substr($this->iCurrentPosition, $mValue);
 			$this->iCurrentPosition += $mValue;
-			$this->peekCache = null;
 			return $sResult;
 		}
 	}


### PR DESCRIPTION
The basic idea is to use an array of characters instead of string processing.

**Benchmark**
For test I took the current css-file from github.com: https://assets-cdn.github.com/assets/github-a15e59d993eb0844d736a04652f63d465d909127e84cf7cd27073076df530f05.css
```php
$source = file_get_contents('https://assets-cdn.github.com/assets/github-a15e59d993eb0844d736a04652f63d465d909127e84cf7cd27073076df530f05.css');
$time = microtime(true);
$parser = new Sabberworm\CSS\Parser($source);
$css = $parser->parse();
var_dump(microtime(true) - $time);
```
On the my machine I received the following results:
before `float(180.93577218056)`
after `float(1.1720938682556)`