### PR TITLE
Add line number support in the sabberworm CSS parser

### DIFF
--- a/lib/Sabberworm/CSS/CSSList/AtRuleBlockList.php
+++ b/lib/Sabberworm/CSS/CSSList/AtRuleBlockList.php
@@ -12,8 +12,8 @@ class AtRuleBlockList extends CSSBlockList implements AtRule {
 	private $sType;
 	private $sArgs;
 
-	public function __construct($sType, $sArgs = '', $iLineNum = 0) {
-		parent::__construct($iLineNum);
+	public function __construct($sType, $sArgs = '', $iLineNo = 0) {
+		parent::__construct($iLineNo);
 		$this->sType = $sType;
 		$this->sArgs = $sArgs;
 	}

--- a/lib/Sabberworm/CSS/CSSList/AtRuleBlockList.php
+++ b/lib/Sabberworm/CSS/CSSList/AtRuleBlockList.php
@@ -12,8 +12,8 @@ class AtRuleBlockList extends CSSBlockList implements AtRule {
 	private $sType;
 	private $sArgs;
 
-	public function __construct($sType, $sArgs = '') {
-		parent::__construct();
+	public function __construct($sType, $sArgs = '', $iLineNum = 0) {
+		parent::__construct($iLineNum);
 		$this->sType = $sType;
 		$this->sArgs = $sArgs;
 	}

--- a/lib/Sabberworm/CSS/CSSList/CSSBlockList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSBlockList.php
@@ -14,6 +14,10 @@ use Sabberworm\CSS\Value\CSSFunction;
  * Most CSSLists conform to this category but some at-rules (such as @keyframes) do not.
  */
 abstract class CSSBlockList extends CSSList {
+	public function __construct($iLineNum = 0) {
+		parent::__construct($iLineNum);
+	}
+
 	protected function allDeclarationBlocks(&$aResult) {
 		foreach ($this->aContents as $mContent) {
 			if ($mContent instanceof DeclarationBlock) {

--- a/lib/Sabberworm/CSS/CSSList/CSSBlockList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSBlockList.php
@@ -14,8 +14,8 @@ use Sabberworm\CSS\Value\CSSFunction;
  * Most CSSLists conform to this category but some at-rules (such as @keyframes) do not.
  */
 abstract class CSSBlockList extends CSSList {
-	public function __construct($iLineNum = 0) {
-		parent::__construct($iLineNum);
+	public function __construct($iLineNo = 0) {
+		parent::__construct($iLineNo);
 	}
 
 	protected function allDeclarationBlocks(&$aResult) {

--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -2,18 +2,16 @@
 
 namespace Sabberworm\CSS\CSSList;
 
+use Sabberworm\CSS\Renderable;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
 use Sabberworm\CSS\RuleSet\RuleSet;
 use Sabberworm\CSS\Property\Selector;
-use Sabberworm\CSS\Rule\Rule;
-use Sabberworm\CSS\Value\ValueList;
-use Sabberworm\CSS\Value\CSSFunction;
 
 /**
  * A CSSList is the most generic container available. Its contents include RuleSet as well as other CSSList objects.
  * Also, it may contain Import and Charset objects stemming from @-rules.
  */
-abstract class CSSList {
+abstract class CSSList implements Renderable {
 
 	protected $aContents;
 	protected $iLineNum;

--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -29,6 +29,14 @@ abstract class CSSList implements Renderable {
 		return $this->iLineNum;
 	}
 
+	/**
+	 * @param int $iLineNum
+	 */
+	public function setLineNo($iLineNum = 0)
+	{
+		$this->iLineNum = $iLineNum;
+	}
+
 	public function append($oItem) {
 		$this->aContents[] = $oItem;
 	}

--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -24,16 +24,14 @@ abstract class CSSList implements Renderable {
 	/**
 	 * @return int
 	 */
-	public function getLineNo()
-	{
+	public function getLineNo() {
 		return $this->iLineNo;
 	}
 
 	/**
 	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNo = 0)
-	{
+	public function setLineNo($iLineNo = 0) {
 		$this->iLineNo = $iLineNo;
 	}
 

--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -14,11 +14,11 @@ use Sabberworm\CSS\Property\Selector;
 abstract class CSSList implements Renderable {
 
 	protected $aContents;
-	protected $iLineNum;
+	protected $iLineNo;
 
-	public function __construct($iLineNum = 0) {
+	public function __construct($iLineNo = 0) {
 		$this->aContents = array();
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	/**
@@ -26,15 +26,15 @@ abstract class CSSList implements Renderable {
 	 */
 	public function getLineNo()
 	{
-		return $this->iLineNum;
+		return $this->iLineNo;
 	}
 
 	/**
-	 * @param int $iLineNum
+	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNum = 0)
+	public function setLineNo($iLineNo = 0)
 	{
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	public function append($oItem) {

--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -28,13 +28,6 @@ abstract class CSSList implements Renderable {
 		return $this->iLineNo;
 	}
 
-	/**
-	 * @param int $iLineNo
-	 */
-	public function setLineNo($iLineNo = 0) {
-		$this->iLineNo = $iLineNo;
-	}
-
 	public function append($oItem) {
 		$this->aContents[] = $oItem;
 	}

--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -16,9 +16,19 @@ use Sabberworm\CSS\Value\CSSFunction;
 abstract class CSSList {
 
 	protected $aContents;
+	protected $iLineNum;
 
-	public function __construct() {
+	public function __construct($iLineNum = 0) {
 		$this->aContents = array();
+		$this->iLineNum = $iLineNum;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getLineNum()
+	{
+		return $this->iLineNum;
 	}
 
 	public function append($oItem) {

--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -24,7 +24,7 @@ abstract class CSSList implements Renderable {
 	/**
 	 * @return int
 	 */
-	public function getLineNum()
+	public function getLineNo()
 	{
 		return $this->iLineNum;
 	}

--- a/lib/Sabberworm/CSS/CSSList/Document.php
+++ b/lib/Sabberworm/CSS/CSSList/Document.php
@@ -8,11 +8,11 @@ namespace Sabberworm\CSS\CSSList;
 class Document extends CSSBlockList {
 	/**
 	 * Document constructor.
-	 * @param int $iLineNum
+	 * @param int $iLineNo
 	 */
-	public function __construct($iLineNum = 0)
+	public function __construct($iLineNo = 0)
 	{
-		parent::__construct($iLineNum);
+		parent::__construct($iLineNo);
 	}
 
 	/**

--- a/lib/Sabberworm/CSS/CSSList/Document.php
+++ b/lib/Sabberworm/CSS/CSSList/Document.php
@@ -6,6 +6,14 @@ namespace Sabberworm\CSS\CSSList;
  * The root CSSList of a parsed file. Contains all top-level css contents, mostly declaration blocks, but also any @-rules encountered.
  */
 class Document extends CSSBlockList {
+	/**
+	 * Document constructor.
+	 * @param int $iLineNum
+	 */
+	public function __construct($iLineNum = 0)
+	{
+		parent::__construct($iLineNum);
+	}
 
 	/**
 	 * Gets all DeclarationBlock objects recursively.

--- a/lib/Sabberworm/CSS/CSSList/Document.php
+++ b/lib/Sabberworm/CSS/CSSList/Document.php
@@ -10,8 +10,7 @@ class Document extends CSSBlockList {
 	 * Document constructor.
 	 * @param int $iLineNo
 	 */
-	public function __construct($iLineNo = 0)
-	{
+	public function __construct($iLineNo = 0) {
 		parent::__construct($iLineNo);
 	}
 

--- a/lib/Sabberworm/CSS/CSSList/KeyFrame.php
+++ b/lib/Sabberworm/CSS/CSSList/KeyFrame.php
@@ -9,8 +9,8 @@ class KeyFrame extends CSSList implements AtRule {
 	private $vendorKeyFrame;
 	private $animationName;
 
-	public function __construct() {
-		parent::__construct();
+	public function __construct($iLineNum = 0) {
+		parent::__construct($iLineNum);
 		$this->vendorKeyFrame = null;
 		$this->animationName  = null;
 	}

--- a/lib/Sabberworm/CSS/CSSList/KeyFrame.php
+++ b/lib/Sabberworm/CSS/CSSList/KeyFrame.php
@@ -9,8 +9,8 @@ class KeyFrame extends CSSList implements AtRule {
 	private $vendorKeyFrame;
 	private $animationName;
 
-	public function __construct($iLineNum = 0) {
-		parent::__construct($iLineNum);
+	public function __construct($iLineNo = 0) {
+		parent::__construct($iLineNo);
 		$this->vendorKeyFrame = null;
 		$this->animationName  = null;
 	}

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -37,7 +37,7 @@ class Parser {
 	private $aSizeUnits;
 	private $iLineNo;
 
-	public function __construct($sText, Settings $oParserSettings = null, $iLineNo = 0) {
+	public function __construct($sText, Settings $oParserSettings = null, $iLineNo = 1) {
 		$this->sText = $sText;
 		$this->iCurrentPosition = 0;
 		$this->iLineNo = $iLineNo;

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -34,12 +34,12 @@ class Parser {
 	private $iLength;
 	private $blockRules;
 	private $aSizeUnits;
-	private $iLineNum;
+	private $iLineNo;
 
-	public function __construct($sText, Settings $oParserSettings = null, $iLineNum = 0) {
+	public function __construct($sText, Settings $oParserSettings = null, $iLineNo = 0) {
 		$this->sText = $sText;
 		$this->iCurrentPosition = 0;
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 		if ($oParserSettings === null) {
 			$oParserSettings = Settings::create();
 		}
@@ -68,7 +68,7 @@ class Parser {
 
 	public function parse() {
 		$this->setCharset($this->oParserSettings->sDefaultCharset);
-		$oResult = new Document($this->iLineNum);
+		$oResult = new Document($this->iLineNo);
 		$this->parseDocument($oResult);
 		return $oResult;
 	}
@@ -109,10 +109,10 @@ class Parser {
 			$oAtRule = $this->parseAtRule();
 			if($oAtRule instanceof Charset) {
 				if(!$bIsRoot) {
-					throw new UnexpectedTokenException('@charset may only occur in root document', '', 'custom', $this->iLineNum);
+					throw new UnexpectedTokenException('@charset may only occur in root document', '', 'custom', $this->iLineNo);
 				}
 				if(count($oList->getContents()) > 0) {
-					throw new UnexpectedTokenException('@charset must be the first parseable token in a document', '', 'custom', $this->iLineNum);
+					throw new UnexpectedTokenException('@charset must be the first parseable token in a document', '', 'custom', $this->iLineNo);
 				}
 				$this->setCharset($oAtRule->getCharset()->getString());
 			}
@@ -132,7 +132,7 @@ class Parser {
 	private function parseAtRule() {
 		$this->consume('@');
 		$sIdentifier = $this->parseIdentifier();
-		$iIdentifierLineNum = $this->iLineNum;
+		$iIdentifierLineNum = $this->iLineNo;
 		$this->consumeWhiteSpace();
 		if ($sIdentifier === 'import') {
 			$oLocation = $this->parseURLValue();
@@ -195,7 +195,7 @@ class Parser {
 	private function parseIdentifier($bAllowFunctions = true, $bIgnoreCase = true) {
 		$sResult = $this->parseCharacter(true);
 		if ($sResult === null) {
-			throw new UnexpectedTokenException($sResult, $this->peek(5), 'identifier', $this->iLineNum);
+			throw new UnexpectedTokenException($sResult, $this->peek(5), 'identifier', $this->iLineNo);
 		}
 		$sCharacter = null;
 		while (($sCharacter = $this->parseCharacter(true)) !== null) {
@@ -207,7 +207,7 @@ class Parser {
 		if ($bAllowFunctions && $this->comes('(')) {
 			$this->consume('(');
 			$aArguments = $this->parseValue(array('=', ' ', ','));
-			$sResult = new CSSFunction($sResult, $aArguments, ',', $this->iLineNum);
+			$sResult = new CSSFunction($sResult, $aArguments, ',', $this->iLineNo);
 			$this->consume(')');
 		}
 		return $sResult;
@@ -241,7 +241,7 @@ class Parser {
 			}
 			$this->consume($sQuote);
 		}
-		return new CSSString($sResult, $this->iLineNum);
+		return new CSSString($sResult, $this->iLineNo);
 	}
 
 	private function parseCharacter($bIsForIdentifier) {
@@ -290,7 +290,7 @@ class Parser {
 	}
 
 	private function parseSelector() {
-		$oResult = new DeclarationBlock($this->iLineNum);
+		$oResult = new DeclarationBlock($this->iLineNo);
 		$oResult->setSelector($this->consumeUntil('{', false, true));
 		$this->consumeWhiteSpace();
 		$this->parseRuleSet($oResult);
@@ -336,7 +336,7 @@ class Parser {
 	}
 
 	private function parseRule() {
-		$oRule = new Rule($this->parseIdentifier(), $this->iLineNum);
+		$oRule = new Rule($this->parseIdentifier(), $this->iLineNo);
 		$this->consumeWhiteSpace();
 		$this->consume(':');
 		$oValue = $this->parseValue(self::listDelimiterForRule($oRule->getRule()));
@@ -390,7 +390,7 @@ class Parser {
 						break;
 					}
 				}
-				$oList = new RuleValueList($sDelimiter, $this->iLineNum);
+				$oList = new RuleValueList($sDelimiter, $this->iLineNo);
 				for ($i = $iStartPosition - 1; $i - $iStartPosition + 1 < $iLength * 2; $i+=2) {
 					$oList->addListComponent($aStack[$i]);
 				}
@@ -448,7 +448,7 @@ class Parser {
 				}
 			}
 		}
-		return new Size(floatval($sSize), $sUnit, $bForColor, $this->iLineNum);
+		return new Size(floatval($sSize), $sUnit, $bForColor, $this->iLineNo);
 	}
 
 	private function parseColorValue() {
@@ -459,7 +459,7 @@ class Parser {
 			if ($this->strlen($sValue) === 3) {
 				$sValue = $sValue[0] . $sValue[0] . $sValue[1] . $sValue[1] . $sValue[2] . $sValue[2];
 			}
-			$aColor = array('r' => new Size(intval($sValue[0] . $sValue[1], 16), null, true, $this->iLineNum), 'g' => new Size(intval($sValue[2] . $sValue[3], 16), null, true, $this->iLineNum), 'b' => new Size(intval($sValue[4] . $sValue[5], 16), null, true, $this->iLineNum));
+			$aColor = array('r' => new Size(intval($sValue[0] . $sValue[1], 16), null, true, $this->iLineNo), 'g' => new Size(intval($sValue[2] . $sValue[3], 16), null, true, $this->iLineNo), 'b' => new Size(intval($sValue[4] . $sValue[5], 16), null, true, $this->iLineNo));
 		} else {
 			$sColorMode = $this->parseIdentifier(false);
 			$this->consumeWhiteSpace();
@@ -475,7 +475,7 @@ class Parser {
 			}
 			$this->consume(')');
 		}
-		return new Color($aColor, $this->iLineNum);
+		return new Color($aColor, $this->iLineNo);
 	}
 
 	private function parseURLValue() {
@@ -486,7 +486,7 @@ class Parser {
 			$this->consume('(');
 		}
 		$this->consumeWhiteSpace();
-		$oResult = new URL($this->parseStringValue(), $this->iLineNum);
+		$oResult = new URL($this->parseStringValue(), $this->iLineNo);
 		if ($bUseUrl) {
 			$this->consumeWhiteSpace();
 			$this->consume(')');
@@ -522,18 +522,18 @@ class Parser {
 			$iLineCount = substr_count($mValue, "\n");
 			$iLength = $this->strlen($mValue);
 			if (!$this->streql($this->substr($this->iCurrentPosition, $iLength), $mValue)) {
-				throw new UnexpectedTokenException($mValue, $this->peek(max($iLength, 5)), $this->iLineNum);
+				throw new UnexpectedTokenException($mValue, $this->peek(max($iLength, 5)), $this->iLineNo);
 			}
-			$this->iLineNum += $iLineCount;
+			$this->iLineNo += $iLineCount;
 			$this->iCurrentPosition += $this->strlen($mValue);
 			return $mValue;
 		} else {
 			if ($this->iCurrentPosition + $mValue > $this->iLength) {
-				throw new UnexpectedTokenException($mValue, $this->peek(5), 'count', $this->iLineNum);
+				throw new UnexpectedTokenException($mValue, $this->peek(5), 'count', $this->iLineNo);
 			}
 			$sResult = $this->substr($this->iCurrentPosition, $mValue);
 			$iLineCount = substr_count($sResult, "\n");
-			$this->iLineNum += $iLineCount;
+			$this->iLineNo += $iLineCount;
 			$this->iCurrentPosition += $mValue;
 			return $sResult;
 		}
@@ -544,7 +544,7 @@ class Parser {
 		if (preg_match($mExpression, $this->inputLeft(), $aMatches, PREG_OFFSET_CAPTURE) === 1) {
 			return $this->consume($aMatches[0][0]);
 		}
-		throw new UnexpectedTokenException($mExpression, $this->peek(5), 'expression', $this->iLineNum);
+		throw new UnexpectedTokenException($mExpression, $this->peek(5), 'expression', $this->iLineNo);
 	}
 
 	private function consumeWhiteSpace() {
@@ -602,7 +602,7 @@ class Parser {
 		}
 
 		$this->iCurrentPosition = $start;
-		throw new UnexpectedTokenException('One of ("'.implode('","', $aEnd).'")', $this->peek(5), 'search', $this->iLineNum);
+		throw new UnexpectedTokenException('One of ("'.implode('","', $aEnd).'")', $this->peek(5), 'search', $this->iLineNo);
 	}
 
 	private function inputLeft() {

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -132,6 +132,7 @@ class Parser {
 	private function parseAtRule() {
 		$this->consume('@');
 		$sIdentifier = $this->parseIdentifier();
+		$iIdentifierLineNum = $this->iLineNum;
 		$this->consumeWhiteSpace();
 		if ($sIdentifier === 'import') {
 			$oLocation = $this->parseURLValue();
@@ -141,14 +142,14 @@ class Parser {
 				$sMediaQuery = $this->consumeUntil(';');
 			}
 			$this->consume(';');
-			return new Import($oLocation, $sMediaQuery, $this->iLineNum);
+			return new Import($oLocation, $sMediaQuery, $iIdentifierLineNum);
 		} else if ($sIdentifier === 'charset') {
 			$sCharset = $this->parseStringValue();
 			$this->consumeWhiteSpace();
 			$this->consume(';');
-			return new Charset($sCharset, $this->iLineNum);
+			return new Charset($sCharset, $iIdentifierLineNum);
 		} else if ($this->identifierIs($sIdentifier, 'keyframes')) {
-			$oResult = new KeyFrame($this->iLineNum);
+			$oResult = new KeyFrame($iIdentifierLineNum);
 			$oResult->setVendorKeyFrame($sIdentifier);
 			$oResult->setAnimationName(trim($this->consumeUntil('{', false, true)));
 			$this->consumeWhiteSpace();
@@ -168,7 +169,7 @@ class Parser {
 			if (!($mUrl instanceof CSSString || $mUrl instanceof URL)) {
 				throw new UnexpectedTokenException('Wrong namespace url of invalid type', $mUrl, 'custom');
 			}
-			return new CSSNamespace($mUrl, $sPrefix, $this->iLineNum);
+			return new CSSNamespace($mUrl, $sPrefix, $iIdentifierLineNum);
 		} else {
 			//Unknown other at rule (font-face or such)
 			$sArgs = trim($this->consumeUntil('{', false, true));
@@ -181,10 +182,10 @@ class Parser {
 				}
 			}
 			if($bUseRuleSet) {
-				$oAtRule = new AtRuleSet($sIdentifier, $sArgs, $this->iLineNum);
+				$oAtRule = new AtRuleSet($sIdentifier, $sArgs, $iIdentifierLineNum);
 				$this->parseRuleSet($oAtRule);
 			} else {
-				$oAtRule = new AtRuleBlockList($sIdentifier, $sArgs, $this->iLineNum);
+				$oAtRule = new AtRuleBlockList($sIdentifier, $sArgs, $iIdentifierLineNum);
 				$this->parseList($oAtRule);
 			}
 			return $oAtRule;

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -5,6 +5,7 @@ namespace Sabberworm\CSS;
 use Sabberworm\CSS\CSSList\CSSList;
 use Sabberworm\CSS\CSSList\Document;
 use Sabberworm\CSS\CSSList\KeyFrame;
+use Sabberworm\CSS\Parsing\SourceException;
 use Sabberworm\CSS\Property\AtRule;
 use Sabberworm\CSS\Property\Import;
 use Sabberworm\CSS\Property\Charset;
@@ -100,7 +101,7 @@ class Parser {
 			$this->consumeWhiteSpace();
 		}
 		if (!$bIsRoot) {
-			throw new \Exception("Unexpected end of document");
+			throw new SourceException("Unexpected end of document", $this->iLineNo);
 		}
 	}
 	
@@ -120,7 +121,7 @@ class Parser {
 		} else if ($this->comes('}')) {
 			$this->consume('}');
 			if ($bIsRoot) {
-				throw new \Exception("Unopened {");
+				throw new SourceException("Unopened {", $this->iLineNo);
 			} else {
 				return null;
 			}
@@ -235,7 +236,7 @@ class Parser {
 			while (!$this->comes($sQuote)) {
 				$sContent = $this->parseCharacter(false);
 				if ($sContent === null) {
-					throw new \Exception("Non-well-formed quoted string {$this->peek(3)}");
+					throw new \Exception("Non-well-formed quoted string {$this->peek(3)}", $this->iLineNo);
 				}
 				$sResult .= $sContent;
 			}

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -519,22 +519,21 @@ class Parser {
 
 	private function consume($mValue = 1) {
 		if (is_string($mValue)) {
-			$noLines = substr_count($mValue, "\n");
+			$iLineCount = substr_count($mValue, "\n");
 			$iLength = $this->strlen($mValue);
 			if (!$this->streql($this->substr($this->iCurrentPosition, $iLength), $mValue)) {
 				throw new UnexpectedTokenException($mValue, $this->peek(max($iLength, 5)));
 			}
-			$this->iLineNum += $noLines;
+			$this->iLineNum += $iLineCount;
 			$this->iCurrentPosition += $this->strlen($mValue);
 			return $mValue;
 		} else {
-			$substring = $this->substr($this->iCurrentPosition, $mValue);
-			$noLines = substr_count($substring, "\n");
-			$this->iLineNum += $noLines;
 			if ($this->iCurrentPosition + $mValue > $this->iLength) {
 				throw new UnexpectedTokenException($mValue, $this->peek(5), 'count');
 			}
 			$sResult = $this->substr($this->iCurrentPosition, $mValue);
+			$iLineCount = substr_count($sResult, "\n");
+			$this->iLineNum += $iLineCount;
 			$this->iCurrentPosition += $mValue;
 			return $sResult;
 		}

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -236,7 +236,7 @@ class Parser {
 			while (!$this->comes($sQuote)) {
 				$sContent = $this->parseCharacter(false);
 				if ($sContent === null) {
-					throw new \Exception("Non-well-formed quoted string {$this->peek(3)}", $this->iLineNo);
+					throw new SourceException("Non-well-formed quoted string {$this->peek(3)}", $this->iLineNo);
 				}
 				$sResult .= $sContent;
 			}

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -109,10 +109,10 @@ class Parser {
 			$oAtRule = $this->parseAtRule();
 			if($oAtRule instanceof Charset) {
 				if(!$bIsRoot) {
-					throw new UnexpectedTokenException('@charset may only occur in root document', '', 'custom');
+					throw new UnexpectedTokenException('@charset may only occur in root document', '', 'custom', $this->iLineNum);
 				}
 				if(count($oList->getContents()) > 0) {
-					throw new UnexpectedTokenException('@charset must be the first parseable token in a document', '', 'custom');
+					throw new UnexpectedTokenException('@charset must be the first parseable token in a document', '', 'custom', $this->iLineNum);
 				}
 				$this->setCharset($oAtRule->getCharset()->getString());
 			}
@@ -164,10 +164,10 @@ class Parser {
 			}
 			$this->consume(';');
 			if ($sPrefix !== null && !is_string($sPrefix)) {
-				throw new UnexpectedTokenException('Wrong namespace prefix', $sPrefix, 'custom');
+				throw new UnexpectedTokenException('Wrong namespace prefix', $sPrefix, 'custom', $iIdentifierLineNum);
 			}
 			if (!($mUrl instanceof CSSString || $mUrl instanceof URL)) {
-				throw new UnexpectedTokenException('Wrong namespace url of invalid type', $mUrl, 'custom');
+				throw new UnexpectedTokenException('Wrong namespace url of invalid type', $mUrl, 'custom', $iIdentifierLineNum);
 			}
 			return new CSSNamespace($mUrl, $sPrefix, $iIdentifierLineNum);
 		} else {
@@ -195,7 +195,7 @@ class Parser {
 	private function parseIdentifier($bAllowFunctions = true, $bIgnoreCase = true) {
 		$sResult = $this->parseCharacter(true);
 		if ($sResult === null) {
-			throw new UnexpectedTokenException($sResult, $this->peek(5), 'identifier');
+			throw new UnexpectedTokenException($sResult, $this->peek(5), 'identifier', $this->iLineNum);
 		}
 		$sCharacter = null;
 		while (($sCharacter = $this->parseCharacter(true)) !== null) {
@@ -522,14 +522,14 @@ class Parser {
 			$iLineCount = substr_count($mValue, "\n");
 			$iLength = $this->strlen($mValue);
 			if (!$this->streql($this->substr($this->iCurrentPosition, $iLength), $mValue)) {
-				throw new UnexpectedTokenException($mValue, $this->peek(max($iLength, 5)));
+				throw new UnexpectedTokenException($mValue, $this->peek(max($iLength, 5)), $this->iLineNum);
 			}
 			$this->iLineNum += $iLineCount;
 			$this->iCurrentPosition += $this->strlen($mValue);
 			return $mValue;
 		} else {
 			if ($this->iCurrentPosition + $mValue > $this->iLength) {
-				throw new UnexpectedTokenException($mValue, $this->peek(5), 'count');
+				throw new UnexpectedTokenException($mValue, $this->peek(5), 'count', $this->iLineNum);
 			}
 			$sResult = $this->substr($this->iCurrentPosition, $mValue);
 			$iLineCount = substr_count($sResult, "\n");
@@ -544,7 +544,7 @@ class Parser {
 		if (preg_match($mExpression, $this->inputLeft(), $aMatches, PREG_OFFSET_CAPTURE) === 1) {
 			return $this->consume($aMatches[0][0]);
 		}
-		throw new UnexpectedTokenException($mExpression, $this->peek(5), 'expression');
+		throw new UnexpectedTokenException($mExpression, $this->peek(5), 'expression', $this->iLineNum);
 	}
 
 	private function consumeWhiteSpace() {
@@ -602,7 +602,7 @@ class Parser {
 		}
 
 		$this->iCurrentPosition = $start;
-		throw new UnexpectedTokenException('One of ("'.implode('","', $aEnd).'")', $this->peek(5), 'search');
+		throw new UnexpectedTokenException('One of ("'.implode('","', $aEnd).'")', $this->peek(5), 'search', $this->iLineNum);
 	}
 
 	private function inputLeft() {

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -37,6 +37,14 @@ class Parser {
 	private $aSizeUnits;
 	private $iLineNo;
 
+	/**
+	 * Parser constructor.
+	 * Note that that iLineNo starts from 1 and not 0
+	 *
+	 * @param $sText
+	 * @param Settings|null $oParserSettings
+	 * @param int $iLineNo
+	 */
 	public function __construct($sText, Settings $oParserSettings = null, $iLineNo = 1) {
 		$this->sText = $sText;
 		$this->iCurrentPosition = 0;

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -34,11 +34,12 @@ class Parser {
 	private $iLength;
 	private $blockRules;
 	private $aSizeUnits;
-	private $iLineNum = 1;
+	private $iLineNum;
 
-	public function __construct($sText, Settings $oParserSettings = null) {
+	public function __construct($sText, Settings $oParserSettings = null, $iLineNum = 0) {
 		$this->sText = $sText;
 		$this->iCurrentPosition = 0;
+		$this->iLineNum = $iLineNum;
 		if ($oParserSettings === null) {
 			$oParserSettings = Settings::create();
 		}

--- a/lib/Sabberworm/CSS/Parsing/OutputException.php
+++ b/lib/Sabberworm/CSS/Parsing/OutputException.php
@@ -6,12 +6,12 @@ namespace Sabberworm\CSS\Parsing;
 * Thrown if the CSS parsers attempts to print something invalid
 */
 class OutputException extends \Exception {
-    private $iLineNum;
-    public function __construct($sMessage, $iLineNum = 0)
+    private $iLineNo;
+    public function __construct($sMessage, $iLineNo = 0)
     {
-        $this->$iLineNum = $iLineNum;
-        if (!empty($iLineNum)) {
-            $sMessage .= " [line no: $iLineNum]";
+        $this->$iLineNo = $iLineNo;
+        if (!empty($iLineNo)) {
+            $sMessage .= " [line no: $iLineNo]";
         }
         parent::__construct($sMessage);
     }

--- a/lib/Sabberworm/CSS/Parsing/OutputException.php
+++ b/lib/Sabberworm/CSS/Parsing/OutputException.php
@@ -5,17 +5,8 @@ namespace Sabberworm\CSS\Parsing;
 /**
 * Thrown if the CSS parsers attempts to print something invalid
 */
-class OutputException extends \Exception {
-    private $iLineNo;
+class OutputException extends SourceException {
     public function __construct($sMessage, $iLineNo = 0) {
-        $this->$iLineNo = $iLineNo;
-        if (!empty($iLineNo)) {
-            $sMessage .= " [line no: $iLineNo]";
-        }
-        parent::__construct($sMessage);
-    }
-
-    public function getLineNo() {
-        return $this->iLineNo;
+        parent::__construct($sMessage, $iLineNo);
     }
 }

--- a/lib/Sabberworm/CSS/Parsing/OutputException.php
+++ b/lib/Sabberworm/CSS/Parsing/OutputException.php
@@ -16,6 +16,6 @@ class OutputException extends \Exception {
     }
 
     public function getLineNo() {
-        return $this->getLine();
+        return $this->iLineNo;
     }
 }

--- a/lib/Sabberworm/CSS/Parsing/OutputException.php
+++ b/lib/Sabberworm/CSS/Parsing/OutputException.php
@@ -7,12 +7,15 @@ namespace Sabberworm\CSS\Parsing;
 */
 class OutputException extends \Exception {
     private $iLineNo;
-    public function __construct($sMessage, $iLineNo = 0)
-    {
+    public function __construct($sMessage, $iLineNo = 0) {
         $this->$iLineNo = $iLineNo;
         if (!empty($iLineNo)) {
             $sMessage .= " [line no: $iLineNo]";
         }
         parent::__construct($sMessage);
+    }
+
+    public function getLineNo() {
+        return $this->getLine();
     }
 }

--- a/lib/Sabberworm/CSS/Parsing/OutputException.php
+++ b/lib/Sabberworm/CSS/Parsing/OutputException.php
@@ -6,4 +6,13 @@ namespace Sabberworm\CSS\Parsing;
 * Thrown if the CSS parsers attempts to print something invalid
 */
 class OutputException extends \Exception {
+    private $iLineNum;
+    public function __construct($sMessage, $iLineNum = 0)
+    {
+        $this->$iLineNum = $iLineNum;
+        if (!empty($iLineNum)) {
+            $sMessage .= " [line no: $iLineNum]";
+        }
+        parent::__construct($sMessage);
+    }
 }

--- a/lib/Sabberworm/CSS/Parsing/SourceException.php
+++ b/lib/Sabberworm/CSS/Parsing/SourceException.php
@@ -5,7 +5,7 @@ namespace Sabberworm\CSS\Parsing;
 class SourceException extends \Exception {
     private $iLineNo;
     public function __construct($sMessage, $iLineNo = 0) {
-        $this->$iLineNo = $iLineNo;
+        $this->iLineNo = $iLineNo;
         if (!empty($iLineNo)) {
             $sMessage .= " [line no: $iLineNo]";
         }

--- a/lib/Sabberworm/CSS/Parsing/SourceException.php
+++ b/lib/Sabberworm/CSS/Parsing/SourceException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Sabberworm\CSS\Parsing;
+
+class SourceException extends \Exception {
+    private $iLineNo;
+    public function __construct($sMessage, $iLineNo = 0) {
+        $this->$iLineNo = $iLineNo;
+        if (!empty($iLineNo)) {
+            $sMessage .= " [line no: $iLineNo]";
+        }
+        parent::__construct($sMessage);
+    }
+
+    public function getLineNo() {
+        return $this->iLineNo;
+    }
+}

--- a/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
+++ b/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
@@ -10,11 +10,13 @@ class UnexpectedTokenException extends \Exception {
 	private $sFound;
 	// Possible values: literal, identifier, count, expression, search
 	private $sMatchType;
+	private $iLineNum;
 
-	public function __construct($sExpected, $sFound, $sMatchType = 'literal') {
+	public function __construct($sExpected, $sFound, $sMatchType = 'literal', $iLineNum = 0) {
 		$this->sExpected = $sExpected;
 		$this->sFound = $sFound;
 		$this->sMatchType = $sMatchType;
+		$this->iLineNum = $iLineNum;
 		$sMessage = "Token “{$sExpected}” ({$sMatchType}) not found. Got “{$sFound}”.";
 		if($this->sMatchType === 'search') {
 			$sMessage = "Search for “{$sExpected}” returned no results. Context: “{$sFound}”.";
@@ -25,6 +27,11 @@ class UnexpectedTokenException extends \Exception {
 		} else if($this->sMatchType === 'custom') {
 			$sMessage = trim("$sExpected $sFound");
 		}
+
+		if (!empty($iLineNum)) {
+			$sMessage .= " [line no: $iLineNum]";
+		}
+
 		parent::__construct($sMessage);
 	}
 }

--- a/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
+++ b/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
@@ -34,4 +34,8 @@ class UnexpectedTokenException extends \Exception {
 
 		parent::__construct($sMessage);
 	}
+
+	public function getLineNo() {
+		return $this->getLine();
+	}
 }

--- a/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
+++ b/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
@@ -36,6 +36,6 @@ class UnexpectedTokenException extends \Exception {
 	}
 
 	public function getLineNo() {
-		return $this->getLine();
+		return $this->iLineNo;
 	}
 }

--- a/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
+++ b/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
@@ -10,13 +10,11 @@ class UnexpectedTokenException extends SourceException {
 	private $sFound;
 	// Possible values: literal, identifier, count, expression, search
 	private $sMatchType;
-	private $iLineNo;
 
 	public function __construct($sExpected, $sFound, $sMatchType = 'literal', $iLineNo = 0) {
 		$this->sExpected = $sExpected;
 		$this->sFound = $sFound;
 		$this->sMatchType = $sMatchType;
-		$this->iLineNo = $iLineNo;
 		$sMessage = "Token “{$sExpected}” ({$sMatchType}) not found. Got “{$sFound}”.";
 		if($this->sMatchType === 'search') {
 			$sMessage = "Search for “{$sExpected}” returned no results. Context: “{$sFound}”.";
@@ -29,9 +27,5 @@ class UnexpectedTokenException extends SourceException {
 		}
 
 		parent::__construct($sMessage, $iLineNo);
-	}
-
-	public function getLineNo() {
-		return $this->iLineNo;
 	}
 }

--- a/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
+++ b/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
@@ -5,7 +5,7 @@ namespace Sabberworm\CSS\Parsing;
 /**
 * Thrown if the CSS parsers encounters a token it did not expect
 */
-class UnexpectedTokenException extends \Exception {
+class UnexpectedTokenException extends SourceException {
 	private $sExpected;
 	private $sFound;
 	// Possible values: literal, identifier, count, expression, search
@@ -28,11 +28,7 @@ class UnexpectedTokenException extends \Exception {
 			$sMessage = trim("$sExpected $sFound");
 		}
 
-		if (!empty($iLineNo)) {
-			$sMessage .= " [line no: $iLineNo]";
-		}
-
-		parent::__construct($sMessage);
+		parent::__construct($sMessage, $iLineNo);
 	}
 
 	public function getLineNo() {

--- a/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
+++ b/lib/Sabberworm/CSS/Parsing/UnexpectedTokenException.php
@@ -10,13 +10,13 @@ class UnexpectedTokenException extends \Exception {
 	private $sFound;
 	// Possible values: literal, identifier, count, expression, search
 	private $sMatchType;
-	private $iLineNum;
+	private $iLineNo;
 
-	public function __construct($sExpected, $sFound, $sMatchType = 'literal', $iLineNum = 0) {
+	public function __construct($sExpected, $sFound, $sMatchType = 'literal', $iLineNo = 0) {
 		$this->sExpected = $sExpected;
 		$this->sFound = $sFound;
 		$this->sMatchType = $sMatchType;
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 		$sMessage = "Token “{$sExpected}” ({$sMatchType}) not found. Got “{$sFound}”.";
 		if($this->sMatchType === 'search') {
 			$sMessage = "Search for “{$sExpected}” returned no results. Context: “{$sFound}”.";
@@ -28,8 +28,8 @@ class UnexpectedTokenException extends \Exception {
 			$sMessage = trim("$sExpected $sFound");
 		}
 
-		if (!empty($iLineNum)) {
-			$sMessage .= " [line no: $iLineNum]";
+		if (!empty($iLineNo)) {
+			$sMessage .= " [line no: $iLineNo]";
 		}
 
 		parent::__construct($sMessage);

--- a/lib/Sabberworm/CSS/Property/CSSNamespace.php
+++ b/lib/Sabberworm/CSS/Property/CSSNamespace.php
@@ -8,27 +8,27 @@ namespace Sabberworm\CSS\Property;
 class CSSNamespace implements AtRule {
 	private $mUrl;
 	private $sPrefix;
-	private $iLineNum;
+	private $iLineNo;
 	
-	public function __construct($mUrl, $sPrefix = null, $iLineNum = 0) {
+	public function __construct($mUrl, $sPrefix = null, $iLineNo = 0) {
 		$this->mUrl = $mUrl;
 		$this->sPrefix = $sPrefix;
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	/**
 	 * @return int
 	 */
 	public function getLineNo() {
-		return $this->iLineNum;
+		return $this->iLineNo;
 	}
 
 	/**
-	 * @param int $iLineNum
+	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNum = 0)
+	public function setLineNo($iLineNo = 0)
 	{
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	public function __toString() {

--- a/lib/Sabberworm/CSS/Property/CSSNamespace.php
+++ b/lib/Sabberworm/CSS/Property/CSSNamespace.php
@@ -19,7 +19,7 @@ class CSSNamespace implements AtRule {
 	/**
 	 * @return int
 	 */
-	public function getLineNum() {
+	public function getLineNo() {
 		return $this->iLineNum;
 	}
 

--- a/lib/Sabberworm/CSS/Property/CSSNamespace.php
+++ b/lib/Sabberworm/CSS/Property/CSSNamespace.php
@@ -8,12 +8,21 @@ namespace Sabberworm\CSS\Property;
 class CSSNamespace implements AtRule {
 	private $mUrl;
 	private $sPrefix;
+	private $iLineNum;
 	
-	public function __construct($mUrl, $sPrefix = null) {
+	public function __construct($mUrl, $sPrefix = null, $iLineNum = 0) {
 		$this->mUrl = $mUrl;
 		$this->sPrefix = $sPrefix;
+		$this->iLineNum = $iLineNum;
 	}
-	
+
+	/**
+	 * @return int
+	 */
+	public function getLineNum() {
+		return $this->iLineNum;
+	}
+
 	public function __toString() {
 		return $this->render(new \Sabberworm\CSS\OutputFormat());
 	}

--- a/lib/Sabberworm/CSS/Property/CSSNamespace.php
+++ b/lib/Sabberworm/CSS/Property/CSSNamespace.php
@@ -23,6 +23,14 @@ class CSSNamespace implements AtRule {
 		return $this->iLineNum;
 	}
 
+	/**
+	 * @param int $iLineNum
+	 */
+	public function setLineNo($iLineNum = 0)
+	{
+		$this->iLineNum = $iLineNum;
+	}
+
 	public function __toString() {
 		return $this->render(new \Sabberworm\CSS\OutputFormat());
 	}

--- a/lib/Sabberworm/CSS/Property/CSSNamespace.php
+++ b/lib/Sabberworm/CSS/Property/CSSNamespace.php
@@ -26,8 +26,7 @@ class CSSNamespace implements AtRule {
 	/**
 	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNo = 0)
-	{
+	public function setLineNo($iLineNo = 0) {
 		$this->iLineNo = $iLineNo;
 	}
 

--- a/lib/Sabberworm/CSS/Property/CSSNamespace.php
+++ b/lib/Sabberworm/CSS/Property/CSSNamespace.php
@@ -23,13 +23,6 @@ class CSSNamespace implements AtRule {
 		return $this->iLineNo;
 	}
 
-	/**
-	 * @param int $iLineNo
-	 */
-	public function setLineNo($iLineNo = 0) {
-		$this->iLineNo = $iLineNo;
-	}
-
 	public function __toString() {
 		return $this->render(new \Sabberworm\CSS\OutputFormat());
 	}

--- a/lib/Sabberworm/CSS/Property/Charset.php
+++ b/lib/Sabberworm/CSS/Property/Charset.php
@@ -12,9 +12,18 @@ namespace Sabberworm\CSS\Property;
 class Charset implements AtRule {
 
 	private $sCharset;
+	protected $iLineNum;
 
-	public function __construct($sCharset) {
+	public function __construct($sCharset, $iLineNum = 0) {
 		$this->sCharset = $sCharset;
+		$this->iLineNum = $iLineNum;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getLineNum() {
+		return $this->iLineNum;
 	}
 
 	public function setCharset($sCharset) {

--- a/lib/Sabberworm/CSS/Property/Charset.php
+++ b/lib/Sabberworm/CSS/Property/Charset.php
@@ -12,26 +12,26 @@ namespace Sabberworm\CSS\Property;
 class Charset implements AtRule {
 
 	private $sCharset;
-	protected $iLineNum;
+	protected $iLineNo;
 
-	public function __construct($sCharset, $iLineNum = 0) {
+	public function __construct($sCharset, $iLineNo = 0) {
 		$this->sCharset = $sCharset;
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	/**
 	 * @return int
 	 */
 	public function getLineNo() {
-		return $this->iLineNum;
+		return $this->iLineNo;
 	}
 
 	/**
-	 * @param int $iLineNum
+	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNum = 0)
+	public function setLineNo($iLineNo = 0)
 	{
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	public function setCharset($sCharset) {

--- a/lib/Sabberworm/CSS/Property/Charset.php
+++ b/lib/Sabberworm/CSS/Property/Charset.php
@@ -26,6 +26,14 @@ class Charset implements AtRule {
 		return $this->iLineNum;
 	}
 
+	/**
+	 * @param int $iLineNum
+	 */
+	public function setLineNo($iLineNum = 0)
+	{
+		$this->iLineNum = $iLineNum;
+	}
+
 	public function setCharset($sCharset) {
 		$this->sCharset = $sCharset;
 	}

--- a/lib/Sabberworm/CSS/Property/Charset.php
+++ b/lib/Sabberworm/CSS/Property/Charset.php
@@ -22,7 +22,7 @@ class Charset implements AtRule {
 	/**
 	 * @return int
 	 */
-	public function getLineNum() {
+	public function getLineNo() {
 		return $this->iLineNum;
 	}
 

--- a/lib/Sabberworm/CSS/Property/Charset.php
+++ b/lib/Sabberworm/CSS/Property/Charset.php
@@ -29,8 +29,7 @@ class Charset implements AtRule {
 	/**
 	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNo = 0)
-	{
+	public function setLineNo($iLineNo = 0) {
 		$this->iLineNo = $iLineNo;
 	}
 

--- a/lib/Sabberworm/CSS/Property/Charset.php
+++ b/lib/Sabberworm/CSS/Property/Charset.php
@@ -26,13 +26,6 @@ class Charset implements AtRule {
 		return $this->iLineNo;
 	}
 
-	/**
-	 * @param int $iLineNo
-	 */
-	public function setLineNo($iLineNo = 0) {
-		$this->iLineNo = $iLineNo;
-	}
-
 	public function setCharset($sCharset) {
 		$this->sCharset = $sCharset;
 	}

--- a/lib/Sabberworm/CSS/Property/Import.php
+++ b/lib/Sabberworm/CSS/Property/Import.php
@@ -10,12 +10,21 @@ use Sabberworm\CSS\Value\URL;
 class Import implements AtRule {
 	private $oLocation;
 	private $sMediaQuery;
+	protected $iLineNum;
 	
-	public function __construct(URL $oLocation, $sMediaQuery) {
+	public function __construct(URL $oLocation, $sMediaQuery, $iLineNum = 0) {
 		$this->oLocation = $oLocation;
 		$this->sMediaQuery = $sMediaQuery;
+		$this->iLineNum = $iLineNum;
 	}
-	
+
+	/**
+	 * @return int
+	 */
+	public function getLineNum() {
+		return $this->iLineNum;
+	}
+
 	public function setLocation($oLocation) {
 			$this->oLocation = $oLocation;
 	}

--- a/lib/Sabberworm/CSS/Property/Import.php
+++ b/lib/Sabberworm/CSS/Property/Import.php
@@ -25,13 +25,6 @@ class Import implements AtRule {
 		return $this->iLineNo;
 	}
 
-	/**
-	 * @param int $iLineNo
-	 */
-	public function setLineNo($iLineNo = 0) {
-		$this->iLineNo = $iLineNo;
-	}
-
 	public function setLocation($oLocation) {
 			$this->oLocation = $oLocation;
 	}

--- a/lib/Sabberworm/CSS/Property/Import.php
+++ b/lib/Sabberworm/CSS/Property/Import.php
@@ -10,27 +10,27 @@ use Sabberworm\CSS\Value\URL;
 class Import implements AtRule {
 	private $oLocation;
 	private $sMediaQuery;
-	protected $iLineNum;
+	protected $iLineNo;
 	
-	public function __construct(URL $oLocation, $sMediaQuery, $iLineNum = 0) {
+	public function __construct(URL $oLocation, $sMediaQuery, $iLineNo = 0) {
 		$this->oLocation = $oLocation;
 		$this->sMediaQuery = $sMediaQuery;
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	/**
 	 * @return int
 	 */
 	public function getLineNo() {
-		return $this->iLineNum;
+		return $this->iLineNo;
 	}
 
 	/**
-	 * @param int $iLineNum
+	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNum = 0)
+	public function setLineNo($iLineNo = 0)
 	{
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	public function setLocation($oLocation) {

--- a/lib/Sabberworm/CSS/Property/Import.php
+++ b/lib/Sabberworm/CSS/Property/Import.php
@@ -21,7 +21,7 @@ class Import implements AtRule {
 	/**
 	 * @return int
 	 */
-	public function getLineNum() {
+	public function getLineNo() {
 		return $this->iLineNum;
 	}
 

--- a/lib/Sabberworm/CSS/Property/Import.php
+++ b/lib/Sabberworm/CSS/Property/Import.php
@@ -28,8 +28,7 @@ class Import implements AtRule {
 	/**
 	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNo = 0)
-	{
+	public function setLineNo($iLineNo = 0) {
 		$this->iLineNo = $iLineNo;
 	}
 

--- a/lib/Sabberworm/CSS/Property/Import.php
+++ b/lib/Sabberworm/CSS/Property/Import.php
@@ -25,6 +25,14 @@ class Import implements AtRule {
 		return $this->iLineNum;
 	}
 
+	/**
+	 * @param int $iLineNum
+	 */
+	public function setLineNo($iLineNum = 0)
+	{
+		$this->iLineNum = $iLineNum;
+	}
+
 	public function setLocation($oLocation) {
 			$this->oLocation = $oLocation;
 	}

--- a/lib/Sabberworm/CSS/Renderable.php
+++ b/lib/Sabberworm/CSS/Renderable.php
@@ -5,4 +5,5 @@ namespace Sabberworm\CSS;
 interface Renderable {
 	public function __toString();
 	public function render(\Sabberworm\CSS\OutputFormat $oOutputFormat);
+	public function getLineNo();
 }

--- a/lib/Sabberworm/CSS/Renderable.php
+++ b/lib/Sabberworm/CSS/Renderable.php
@@ -6,4 +6,5 @@ interface Renderable {
 	public function __toString();
 	public function render(\Sabberworm\CSS\OutputFormat $oOutputFormat);
 	public function getLineNo();
+	public function setLineNo();
 }

--- a/lib/Sabberworm/CSS/Renderable.php
+++ b/lib/Sabberworm/CSS/Renderable.php
@@ -6,5 +6,4 @@ interface Renderable {
 	public function __toString();
 	public function render(\Sabberworm\CSS\OutputFormat $oOutputFormat);
 	public function getLineNo();
-	public function setLineNo();
 }

--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -15,13 +15,13 @@ class Rule implements Renderable {
 	private $sRule;
 	private $mValue;
 	private $bIsImportant;
-	protected $iLineNum;
+	protected $iLineNo;
 
-	public function __construct($sRule, $iLineNum = 0) {
+	public function __construct($sRule, $iLineNo = 0) {
 		$this->sRule = $sRule;
 		$this->mValue = null;
 		$this->bIsImportant = false;
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	/**
@@ -29,15 +29,15 @@ class Rule implements Renderable {
 	 */
 	public function getLineNo()
 	{
-		return $this->iLineNum;
+		return $this->iLineNo;
 	}
 
 	/**
-	 * @param int $iLineNum
+	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNum = 0)
+	public function setLineNo($iLineNo = 0)
 	{
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	public function setRule($sRule) {
@@ -62,12 +62,12 @@ class Rule implements Renderable {
 	public function setValues($aSpaceSeparatedValues) {
 		$oSpaceSeparatedList = null;
 		if (count($aSpaceSeparatedValues) > 1) {
-			$oSpaceSeparatedList = new RuleValueList(' ', $this->iLineNum);
+			$oSpaceSeparatedList = new RuleValueList(' ', $this->iLineNo);
 		}
 		foreach ($aSpaceSeparatedValues as $aCommaSeparatedValues) {
 			$oCommaSeparatedList = null;
 			if (count($aCommaSeparatedValues) > 1) {
-				$oCommaSeparatedList = new RuleValueList(',', $this->iLineNum);
+				$oCommaSeparatedList = new RuleValueList(',', $this->iLineNo);
 			}
 			foreach ($aCommaSeparatedValues as $mValue) {
 				if (!$oSpaceSeparatedList && !$oCommaSeparatedList) {
@@ -126,7 +126,7 @@ class Rule implements Renderable {
 		}
 		if (!$this->mValue instanceof RuleValueList || $this->mValue->getListSeparator() !== $sType) {
 			$mCurrentValue = $this->mValue;
-			$this->mValue = new RuleValueList($sType, $this->iLineNum);
+			$this->mValue = new RuleValueList($sType, $this->iLineNo);
 			if ($mCurrentValue) {
 				$this->mValue->addListComponent($mCurrentValue);
 			}

--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -14,11 +14,21 @@ class Rule {
 	private $sRule;
 	private $mValue;
 	private $bIsImportant;
+	protected $iLineNum;
 
-	public function __construct($sRule) {
+	public function __construct($sRule, $iLineNum = 0) {
 		$this->sRule = $sRule;
 		$this->mValue = null;
 		$this->bIsImportant = false;
+		$this->iLineNum = $iLineNum;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getLineNum()
+	{
+		return $this->iLineNum;
 	}
 
 	public function setRule($sRule) {
@@ -43,12 +53,12 @@ class Rule {
 	public function setValues($aSpaceSeparatedValues) {
 		$oSpaceSeparatedList = null;
 		if (count($aSpaceSeparatedValues) > 1) {
-			$oSpaceSeparatedList = new RuleValueList(' ');
+			$oSpaceSeparatedList = new RuleValueList(' ', $this->iLineNum);
 		}
 		foreach ($aSpaceSeparatedValues as $aCommaSeparatedValues) {
 			$oCommaSeparatedList = null;
 			if (count($aCommaSeparatedValues) > 1) {
-				$oCommaSeparatedList = new RuleValueList(',');
+				$oCommaSeparatedList = new RuleValueList(',', $this->iLineNum);
 			}
 			foreach ($aCommaSeparatedValues as $mValue) {
 				if (!$oSpaceSeparatedList && !$oCommaSeparatedList) {
@@ -107,7 +117,7 @@ class Rule {
 		}
 		if (!$this->mValue instanceof RuleValueList || $this->mValue->getListSeparator() !== $sType) {
 			$mCurrentValue = $this->mValue;
-			$this->mValue = new RuleValueList($sType);
+			$this->mValue = new RuleValueList($sType, $this->iLineNum);
 			if ($mCurrentValue) {
 				$this->mValue->addListComponent($mCurrentValue);
 			}

--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -2,6 +2,7 @@
 
 namespace Sabberworm\CSS\Rule;
 
+use Sabberworm\CSS\Renderable;
 use Sabberworm\CSS\Value\RuleValueList;
 use Sabberworm\CSS\Value\Value;
 
@@ -9,7 +10,7 @@ use Sabberworm\CSS\Value\Value;
  * RuleSets contains Rule objects which always have a key and a value.
  * In CSS, Rules are expressed as follows: “key: value[0][0] value[0][1], value[1][0] value[1][1];”
  */
-class Rule {
+class Rule implements Renderable {
 
 	private $sRule;
 	private $mValue;

--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -31,13 +31,6 @@ class Rule implements Renderable {
 		return $this->iLineNo;
 	}
 
-	/**
-	 * @param int $iLineNo
-	 */
-	public function setLineNo($iLineNo = 0) {
-		$this->iLineNo = $iLineNo;
-	}
-
 	public function setRule($sRule) {
 		$this->sRule = $sRule;
 	}

--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -32,6 +32,14 @@ class Rule implements Renderable {
 		return $this->iLineNum;
 	}
 
+	/**
+	 * @param int $iLineNum
+	 */
+	public function setLineNo($iLineNum = 0)
+	{
+		$this->iLineNum = $iLineNum;
+	}
+
 	public function setRule($sRule) {
 		$this->sRule = $sRule;
 	}

--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -27,16 +27,14 @@ class Rule implements Renderable {
 	/**
 	 * @return int
 	 */
-	public function getLineNo()
-	{
+	public function getLineNo() {
 		return $this->iLineNo;
 	}
 
 	/**
 	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNo = 0)
-	{
+	public function setLineNo($iLineNo = 0) {
 		$this->iLineNo = $iLineNo;
 	}
 

--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -26,7 +26,7 @@ class Rule {
 	/**
 	 * @return int
 	 */
-	public function getLineNum()
+	public function getLineNo()
 	{
 		return $this->iLineNum;
 	}

--- a/lib/Sabberworm/CSS/RuleSet/AtRuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/AtRuleSet.php
@@ -12,8 +12,8 @@ class AtRuleSet extends RuleSet implements AtRule {
 	private $sType;
 	private $sArgs;
 
-	public function __construct($sType, $sArgs = '', $iLineNum = 0) {
-		parent::__construct($iLineNum);
+	public function __construct($sType, $sArgs = '', $iLineNo = 0) {
+		parent::__construct($iLineNo);
 		$this->sType = $sType;
 		$this->sArgs = $sArgs;
 	}

--- a/lib/Sabberworm/CSS/RuleSet/AtRuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/AtRuleSet.php
@@ -12,8 +12,8 @@ class AtRuleSet extends RuleSet implements AtRule {
 	private $sType;
 	private $sArgs;
 
-	public function __construct($sType, $sArgs = '') {
-		parent::__construct();
+	public function __construct($sType, $sArgs = '', $iLineNum = 0) {
+		parent::__construct($iLineNum);
 		$this->sType = $sType;
 		$this->sArgs = $sArgs;
 	}

--- a/lib/Sabberworm/CSS/RuleSet/DeclarationBlock.php
+++ b/lib/Sabberworm/CSS/RuleSet/DeclarationBlock.php
@@ -19,8 +19,8 @@ class DeclarationBlock extends RuleSet {
 
 	private $aSelectors;
 
-	public function __construct() {
-		parent::__construct();
+	public function __construct($iLineNum = 0) {
+		parent::__construct($iLineNum);
 		$this->aSelectors = array();
 	}
 
@@ -134,7 +134,7 @@ class DeclarationBlock extends RuleSet {
 						$sNewRuleName = $sBorderRule . "-style";
 					}
 				}
-				$oNewRule = new Rule($sNewRuleName);
+				$oNewRule = new Rule($sNewRuleName, $this->iLineNum);
 				$oNewRule->setIsImportant($oRule->getIsImportant());
 				$oNewRule->addValue(array($mNewValue));
 				$this->addRule($oNewRule);
@@ -190,7 +190,7 @@ class DeclarationBlock extends RuleSet {
 					break;
 			}
 			foreach (array('top', 'right', 'bottom', 'left') as $sPosition) {
-				$oNewRule = new Rule(sprintf($sExpanded, $sPosition));
+				$oNewRule = new Rule(sprintf($sExpanded, $sPosition), $this->iLineNum);
 				$oNewRule->setIsImportant($oRule->getIsImportant());
 				$oNewRule->addValue(${$sPosition});
 				$this->addRule($oNewRule);
@@ -255,7 +255,7 @@ class DeclarationBlock extends RuleSet {
 			}
 		}
 		foreach ($aFontProperties as $sProperty => $mValue) {
-			$oNewRule = new Rule($sProperty);
+			$oNewRule = new Rule($sProperty, $this->iLineNum);
 			$oNewRule->addValue($mValue);
 			$oNewRule->setIsImportant($oRule->getIsImportant());
 			$this->addRule($oNewRule);
@@ -278,7 +278,7 @@ class DeclarationBlock extends RuleSet {
 		$aBgProperties = array(
 			'background-color' => array('transparent'), 'background-image' => array('none'),
 			'background-repeat' => array('repeat'), 'background-attachment' => array('scroll'),
-			'background-position' => array(new Size(0, '%'), new Size(0, '%'))
+			'background-position' => array(new Size(0, '%', null, false, $this->iLineNum), new Size(0, '%', null, false, $this->iLineNum))
 		);
 		$mRuleValue = $oRule->getValue();
 		$aValues = array();
@@ -289,7 +289,7 @@ class DeclarationBlock extends RuleSet {
 		}
 		if (count($aValues) == 1 && $aValues[0] == 'inherit') {
 			foreach ($aBgProperties as $sProperty => $mValue) {
-				$oNewRule = new Rule($sProperty);
+				$oNewRule = new Rule($sProperty, $this->iLineNum);
 				$oNewRule->addValue('inherit');
 				$oNewRule->setIsImportant($oRule->getIsImportant());
 				$this->addRule($oNewRule);
@@ -323,7 +323,7 @@ class DeclarationBlock extends RuleSet {
 			}
 		}
 		foreach ($aBgProperties as $sProperty => $mValue) {
-			$oNewRule = new Rule($sProperty);
+			$oNewRule = new Rule($sProperty, $this->iLineNum);
 			$oNewRule->setIsImportant($oRule->getIsImportant());
 			$oNewRule->addValue($mValue);
 			$this->addRule($oNewRule);
@@ -359,7 +359,7 @@ class DeclarationBlock extends RuleSet {
 		}
 		if (count($aValues) == 1 && $aValues[0] == 'inherit') {
 			foreach ($aListProperties as $sProperty => $mValue) {
-				$oNewRule = new Rule($sProperty);
+				$oNewRule = new Rule($sProperty, $this->iLineNum);
 				$oNewRule->addValue('inherit');
 				$oNewRule->setIsImportant($oRule->getIsImportant());
 				$this->addRule($oNewRule);
@@ -380,7 +380,7 @@ class DeclarationBlock extends RuleSet {
 			}
 		}
 		foreach ($aListProperties as $sProperty => $mValue) {
-			$oNewRule = new Rule($sProperty);
+			$oNewRule = new Rule($sProperty, $this->iLineNum);
 			$oNewRule->setIsImportant($oRule->getIsImportant());
 			$oNewRule->addValue($mValue);
 			$this->addRule($oNewRule);
@@ -410,7 +410,7 @@ class DeclarationBlock extends RuleSet {
 			}
 		}
 		if (count($aNewValues)) {
-			$oNewRule = new Rule($sShorthand);
+			$oNewRule = new Rule($sShorthand, $this->iLineNum);
 			foreach ($aNewValues as $mValue) {
 				$oNewRule->addValue($mValue);
 			}
@@ -483,7 +483,7 @@ class DeclarationBlock extends RuleSet {
 					}
 					$aValues[$sPosition] = $aRuleValues;
 				}
-				$oNewRule = new Rule($sProperty);
+				$oNewRule = new Rule($sProperty, $this->iLineNum);
 				if ((string) $aValues['left'][0] == (string) $aValues['right'][0]) {
 					if ((string) $aValues['top'][0] == (string) $aValues['bottom'][0]) {
 						if ((string) $aValues['top'][0] == (string) $aValues['left'][0]) {
@@ -528,7 +528,7 @@ class DeclarationBlock extends RuleSet {
 		if (!isset($aRules['font-size']) || !isset($aRules['font-family'])) {
 			return;
 		}
-		$oNewRule = new Rule('font');
+		$oNewRule = new Rule('font', $this->iLineNum);
 		foreach (array('font-style', 'font-variant', 'font-weight') as $sProperty) {
 			if (isset($aRules[$sProperty])) {
 				$oRule = $aRules[$sProperty];
@@ -564,7 +564,7 @@ class DeclarationBlock extends RuleSet {
 				$aLHValues = $mRuleValue->getListComponents();
 			}
 			if ($aLHValues[0] !== 'normal') {
-				$val = new RuleValueList('/');
+				$val = new RuleValueList('/', $this->iLineNum);
 				$val->addListComponent($aFSValues[0]);
 				$val->addListComponent($aLHValues[0]);
 				$oNewRule->addValue($val);
@@ -580,7 +580,7 @@ class DeclarationBlock extends RuleSet {
 		} else {
 			$aFFValues = $mRuleValue->getListComponents();
 		}
-		$oFFValue = new RuleValueList(',');
+		$oFFValue = new RuleValueList(',', $this->iLineNum);
 		$oFFValue->setListComponents($aFFValues);
 		$oNewRule->addValue($oFFValue);
 

--- a/lib/Sabberworm/CSS/RuleSet/DeclarationBlock.php
+++ b/lib/Sabberworm/CSS/RuleSet/DeclarationBlock.php
@@ -19,8 +19,8 @@ class DeclarationBlock extends RuleSet {
 
 	private $aSelectors;
 
-	public function __construct($iLineNum = 0) {
-		parent::__construct($iLineNum);
+	public function __construct($iLineNo = 0) {
+		parent::__construct($iLineNo);
 		$this->aSelectors = array();
 	}
 
@@ -134,7 +134,7 @@ class DeclarationBlock extends RuleSet {
 						$sNewRuleName = $sBorderRule . "-style";
 					}
 				}
-				$oNewRule = new Rule($sNewRuleName, $this->iLineNum);
+				$oNewRule = new Rule($sNewRuleName, $this->iLineNo);
 				$oNewRule->setIsImportant($oRule->getIsImportant());
 				$oNewRule->addValue(array($mNewValue));
 				$this->addRule($oNewRule);
@@ -190,7 +190,7 @@ class DeclarationBlock extends RuleSet {
 					break;
 			}
 			foreach (array('top', 'right', 'bottom', 'left') as $sPosition) {
-				$oNewRule = new Rule(sprintf($sExpanded, $sPosition), $this->iLineNum);
+				$oNewRule = new Rule(sprintf($sExpanded, $sPosition), $this->iLineNo);
 				$oNewRule->setIsImportant($oRule->getIsImportant());
 				$oNewRule->addValue(${$sPosition});
 				$this->addRule($oNewRule);
@@ -255,7 +255,7 @@ class DeclarationBlock extends RuleSet {
 			}
 		}
 		foreach ($aFontProperties as $sProperty => $mValue) {
-			$oNewRule = new Rule($sProperty, $this->iLineNum);
+			$oNewRule = new Rule($sProperty, $this->iLineNo);
 			$oNewRule->addValue($mValue);
 			$oNewRule->setIsImportant($oRule->getIsImportant());
 			$this->addRule($oNewRule);
@@ -278,7 +278,7 @@ class DeclarationBlock extends RuleSet {
 		$aBgProperties = array(
 			'background-color' => array('transparent'), 'background-image' => array('none'),
 			'background-repeat' => array('repeat'), 'background-attachment' => array('scroll'),
-			'background-position' => array(new Size(0, '%', null, false, $this->iLineNum), new Size(0, '%', null, false, $this->iLineNum))
+			'background-position' => array(new Size(0, '%', null, false, $this->iLineNo), new Size(0, '%', null, false, $this->iLineNo))
 		);
 		$mRuleValue = $oRule->getValue();
 		$aValues = array();
@@ -289,7 +289,7 @@ class DeclarationBlock extends RuleSet {
 		}
 		if (count($aValues) == 1 && $aValues[0] == 'inherit') {
 			foreach ($aBgProperties as $sProperty => $mValue) {
-				$oNewRule = new Rule($sProperty, $this->iLineNum);
+				$oNewRule = new Rule($sProperty, $this->iLineNo);
 				$oNewRule->addValue('inherit');
 				$oNewRule->setIsImportant($oRule->getIsImportant());
 				$this->addRule($oNewRule);
@@ -323,7 +323,7 @@ class DeclarationBlock extends RuleSet {
 			}
 		}
 		foreach ($aBgProperties as $sProperty => $mValue) {
-			$oNewRule = new Rule($sProperty, $this->iLineNum);
+			$oNewRule = new Rule($sProperty, $this->iLineNo);
 			$oNewRule->setIsImportant($oRule->getIsImportant());
 			$oNewRule->addValue($mValue);
 			$this->addRule($oNewRule);
@@ -359,7 +359,7 @@ class DeclarationBlock extends RuleSet {
 		}
 		if (count($aValues) == 1 && $aValues[0] == 'inherit') {
 			foreach ($aListProperties as $sProperty => $mValue) {
-				$oNewRule = new Rule($sProperty, $this->iLineNum);
+				$oNewRule = new Rule($sProperty, $this->iLineNo);
 				$oNewRule->addValue('inherit');
 				$oNewRule->setIsImportant($oRule->getIsImportant());
 				$this->addRule($oNewRule);
@@ -380,7 +380,7 @@ class DeclarationBlock extends RuleSet {
 			}
 		}
 		foreach ($aListProperties as $sProperty => $mValue) {
-			$oNewRule = new Rule($sProperty, $this->iLineNum);
+			$oNewRule = new Rule($sProperty, $this->iLineNo);
 			$oNewRule->setIsImportant($oRule->getIsImportant());
 			$oNewRule->addValue($mValue);
 			$this->addRule($oNewRule);
@@ -410,7 +410,7 @@ class DeclarationBlock extends RuleSet {
 			}
 		}
 		if (count($aNewValues)) {
-			$oNewRule = new Rule($sShorthand, $this->iLineNum);
+			$oNewRule = new Rule($sShorthand, $this->iLineNo);
 			foreach ($aNewValues as $mValue) {
 				$oNewRule->addValue($mValue);
 			}
@@ -483,7 +483,7 @@ class DeclarationBlock extends RuleSet {
 					}
 					$aValues[$sPosition] = $aRuleValues;
 				}
-				$oNewRule = new Rule($sProperty, $this->iLineNum);
+				$oNewRule = new Rule($sProperty, $this->iLineNo);
 				if ((string) $aValues['left'][0] == (string) $aValues['right'][0]) {
 					if ((string) $aValues['top'][0] == (string) $aValues['bottom'][0]) {
 						if ((string) $aValues['top'][0] == (string) $aValues['left'][0]) {
@@ -528,7 +528,7 @@ class DeclarationBlock extends RuleSet {
 		if (!isset($aRules['font-size']) || !isset($aRules['font-family'])) {
 			return;
 		}
-		$oNewRule = new Rule('font', $this->iLineNum);
+		$oNewRule = new Rule('font', $this->iLineNo);
 		foreach (array('font-style', 'font-variant', 'font-weight') as $sProperty) {
 			if (isset($aRules[$sProperty])) {
 				$oRule = $aRules[$sProperty];
@@ -564,7 +564,7 @@ class DeclarationBlock extends RuleSet {
 				$aLHValues = $mRuleValue->getListComponents();
 			}
 			if ($aLHValues[0] !== 'normal') {
-				$val = new RuleValueList('/', $this->iLineNum);
+				$val = new RuleValueList('/', $this->iLineNo);
 				$val->addListComponent($aFSValues[0]);
 				$val->addListComponent($aLHValues[0]);
 				$oNewRule->addValue($val);
@@ -580,7 +580,7 @@ class DeclarationBlock extends RuleSet {
 		} else {
 			$aFFValues = $mRuleValue->getListComponents();
 		}
-		$oFFValue = new RuleValueList(',', $this->iLineNum);
+		$oFFValue = new RuleValueList(',', $this->iLineNo);
 		$oFFValue->setListComponents($aFFValues);
 		$oNewRule->addValue($oFFValue);
 
@@ -597,7 +597,7 @@ class DeclarationBlock extends RuleSet {
 	public function render(\Sabberworm\CSS\OutputFormat $oOutputFormat) {
 		if(count($this->aSelectors) === 0) {
 			// If all the selectors have been removed, this declaration block becomes invalid
-			throw new OutputException("Attempt to print declaration block with missing selector", $this->iLineNum);
+			throw new OutputException("Attempt to print declaration block with missing selector", $this->iLineNo);
 		}
 		$sResult = $oOutputFormat->implode($oOutputFormat->spaceBeforeSelectorSeparator() . ',' . $oOutputFormat->spaceAfterSelectorSeparator(), $this->aSelectors) . $oOutputFormat->spaceBeforeOpeningBrace() . '{';
 		$sResult .= parent::render($oOutputFormat);

--- a/lib/Sabberworm/CSS/RuleSet/DeclarationBlock.php
+++ b/lib/Sabberworm/CSS/RuleSet/DeclarationBlock.php
@@ -597,7 +597,7 @@ class DeclarationBlock extends RuleSet {
 	public function render(\Sabberworm\CSS\OutputFormat $oOutputFormat) {
 		if(count($this->aSelectors) === 0) {
 			// If all the selectors have been removed, this declaration block becomes invalid
-			throw new OutputException("Attempt to print declaration block with missing selector");
+			throw new OutputException("Attempt to print declaration block with missing selector", $this->iLineNum);
 		}
 		$sResult = $oOutputFormat->implode($oOutputFormat->spaceBeforeSelectorSeparator() . ',' . $oOutputFormat->spaceAfterSelectorSeparator(), $this->aSelectors) . $oOutputFormat->spaceBeforeOpeningBrace() . '{';
 		$sResult .= parent::render($oOutputFormat);

--- a/lib/Sabberworm/CSS/RuleSet/RuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/RuleSet.php
@@ -22,16 +22,14 @@ abstract class RuleSet implements Renderable {
 	/**
 	 * @return int
 	 */
-	public function getLineNo()
-	{
+	public function getLineNo() {
 		return $this->iLineNo;
 	}
 
 	/**
 	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNo = 0)
-	{
+	public function setLineNo($iLineNo = 0) {
 		$this->iLineNo = $iLineNo;
 	}
 

--- a/lib/Sabberworm/CSS/RuleSet/RuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/RuleSet.php
@@ -27,6 +27,14 @@ abstract class RuleSet implements Renderable {
 		return $this->iLineNum;
 	}
 
+	/**
+	 * @param int $iLineNum
+	 */
+	public function setLineNo($iLineNum = 0)
+	{
+		$this->iLineNum = $iLineNum;
+	}
+
 	public function addRule(Rule $oRule) {
 		$sRule = $oRule->getRule();
 		if(!isset($this->aRules[$sRule])) {

--- a/lib/Sabberworm/CSS/RuleSet/RuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/RuleSet.php
@@ -22,7 +22,7 @@ abstract class RuleSet implements Renderable {
 	/**
 	 * @return int
 	 */
-	public function getLineNum()
+	public function getLineNo()
 	{
 		return $this->iLineNum;
 	}

--- a/lib/Sabberworm/CSS/RuleSet/RuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/RuleSet.php
@@ -12,11 +12,11 @@ use Sabberworm\CSS\Renderable;
 abstract class RuleSet implements Renderable {
 
 	private $aRules;
-	protected $iLineNum;
+	protected $iLineNo;
 
-	public function __construct($iLineNum = 0) {
+	public function __construct($iLineNo = 0) {
 		$this->aRules = array();
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	/**
@@ -24,15 +24,15 @@ abstract class RuleSet implements Renderable {
 	 */
 	public function getLineNo()
 	{
-		return $this->iLineNum;
+		return $this->iLineNo;
 	}
 
 	/**
-	 * @param int $iLineNum
+	 * @param int $iLineNo
 	 */
-	public function setLineNo($iLineNum = 0)
+	public function setLineNo($iLineNo = 0)
 	{
-		$this->iLineNum = $iLineNum;
+		$this->iLineNo = $iLineNo;
 	}
 
 	public function addRule(Rule $oRule) {

--- a/lib/Sabberworm/CSS/RuleSet/RuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/RuleSet.php
@@ -12,9 +12,19 @@ use Sabberworm\CSS\Renderable;
 abstract class RuleSet implements Renderable {
 
 	private $aRules;
+	protected $iLineNum;
 
-	public function __construct() {
+	public function __construct($iLineNum = 0) {
 		$this->aRules = array();
+		$this->iLineNum = $iLineNum;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getLineNum()
+	{
+		return $this->iLineNum;
 	}
 
 	public function addRule(Rule $oRule) {

--- a/lib/Sabberworm/CSS/RuleSet/RuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/RuleSet.php
@@ -26,13 +26,6 @@ abstract class RuleSet implements Renderable {
 		return $this->iLineNo;
 	}
 
-	/**
-	 * @param int $iLineNo
-	 */
-	public function setLineNo($iLineNo = 0) {
-		$this->iLineNo = $iLineNo;
-	}
-
 	public function addRule(Rule $oRule) {
 		$sRule = $oRule->getRule();
 		if(!isset($this->aRules[$sRule])) {

--- a/lib/Sabberworm/CSS/Value/CSSFunction.php
+++ b/lib/Sabberworm/CSS/Value/CSSFunction.php
@@ -6,13 +6,14 @@ class CSSFunction extends ValueList {
 
 	private $sName;
 
-	public function __construct($sName, $aArguments, $sSeparator = ',') {
+	public function __construct($sName, $aArguments, $sSeparator = ',', $iLineNum = 0) {
 		if($aArguments instanceof RuleValueList) {
 			$sSeparator = $aArguments->getListSeparator();
 			$aArguments = $aArguments->getListComponents();
 		}
 		$this->sName = $sName;
-		parent::__construct($aArguments, $sSeparator);
+		$this->iLineNum = $iLineNum;
+		parent::__construct($aArguments, $sSeparator, $iLineNum);
 	}
 
 	public function getName() {

--- a/lib/Sabberworm/CSS/Value/CSSFunction.php
+++ b/lib/Sabberworm/CSS/Value/CSSFunction.php
@@ -6,14 +6,14 @@ class CSSFunction extends ValueList {
 
 	private $sName;
 
-	public function __construct($sName, $aArguments, $sSeparator = ',', $iLineNum = 0) {
+	public function __construct($sName, $aArguments, $sSeparator = ',', $iLineNo = 0) {
 		if($aArguments instanceof RuleValueList) {
 			$sSeparator = $aArguments->getListSeparator();
 			$aArguments = $aArguments->getListComponents();
 		}
 		$this->sName = $sName;
-		$this->iLineNum = $iLineNum;
-		parent::__construct($aArguments, $sSeparator, $iLineNum);
+		$this->iLineNo = $iLineNo;
+		parent::__construct($aArguments, $sSeparator, $iLineNo);
 	}
 
 	public function getName() {

--- a/lib/Sabberworm/CSS/Value/CSSString.php
+++ b/lib/Sabberworm/CSS/Value/CSSString.php
@@ -6,9 +6,9 @@ class CSSString extends PrimitiveValue {
 
 	private $sString;
 
-	public function __construct($sString, $iLineNum = 0) {
+	public function __construct($sString, $iLineNo = 0) {
 		$this->sString = $sString;
-		parent::__construct($iLineNum);
+		parent::__construct($iLineNo);
 	}
 
 	public function setString($sString) {

--- a/lib/Sabberworm/CSS/Value/CSSString.php
+++ b/lib/Sabberworm/CSS/Value/CSSString.php
@@ -6,8 +6,9 @@ class CSSString extends PrimitiveValue {
 
 	private $sString;
 
-	public function __construct($sString) {
+	public function __construct($sString, $iLineNum = 0) {
 		$this->sString = $sString;
+		parent::__construct($iLineNum);
 	}
 
 	public function setString($sString) {

--- a/lib/Sabberworm/CSS/Value/Color.php
+++ b/lib/Sabberworm/CSS/Value/Color.php
@@ -4,8 +4,8 @@ namespace Sabberworm\CSS\Value;
 
 class Color extends CSSFunction {
 
-	public function __construct($aColor, $iLineNum = 0) {
-		parent::__construct(implode('', array_keys($aColor)), $aColor, ',', $iLineNum);
+	public function __construct($aColor, $iLineNo = 0) {
+		parent::__construct(implode('', array_keys($aColor)), $aColor, ',', $iLineNo);
 	}
 
 	public function getColor() {
@@ -17,12 +17,12 @@ class Color extends CSSFunction {
 		$this->aComponents = $aColor;
 	}
 
-	public function setLineNo($iLineNum = 0)
+	public function setLineNo($iLineNo = 0)
 	{
 		foreach($this->aComponents as $color_component) {
-			$color_component->setLineNo($iLineNum);
+			$color_component->setLineNo($iLineNo);
 		}
-		parent::setLineNo($iLineNum);
+		parent::setLineNo($iLineNo);
 	}
 
 	public function getColorDescription() {

--- a/lib/Sabberworm/CSS/Value/Color.php
+++ b/lib/Sabberworm/CSS/Value/Color.php
@@ -17,13 +17,6 @@ class Color extends CSSFunction {
 		$this->aComponents = $aColor;
 	}
 
-	public function setLineNo($iLineNo = 0) {
-		foreach($this->aComponents as $color_component) {
-			$color_component->setLineNo($iLineNo);
-		}
-		parent::setLineNo($iLineNo);
-	}
-
 	public function getColorDescription() {
 		return $this->getName();
 	}

--- a/lib/Sabberworm/CSS/Value/Color.php
+++ b/lib/Sabberworm/CSS/Value/Color.php
@@ -17,6 +17,14 @@ class Color extends CSSFunction {
 		$this->aComponents = $aColor;
 	}
 
+	public function setLineNo($iLineNum = 0)
+	{
+		foreach($this->aComponents as $color_component) {
+			$color_component->setLineNo($iLineNum);
+		}
+		parent::setLineNo($iLineNum);
+	}
+
 	public function getColorDescription() {
 		return $this->getName();
 	}

--- a/lib/Sabberworm/CSS/Value/Color.php
+++ b/lib/Sabberworm/CSS/Value/Color.php
@@ -17,8 +17,7 @@ class Color extends CSSFunction {
 		$this->aComponents = $aColor;
 	}
 
-	public function setLineNo($iLineNo = 0)
-	{
+	public function setLineNo($iLineNo = 0) {
 		foreach($this->aComponents as $color_component) {
 			$color_component->setLineNo($iLineNo);
 		}

--- a/lib/Sabberworm/CSS/Value/Color.php
+++ b/lib/Sabberworm/CSS/Value/Color.php
@@ -4,8 +4,8 @@ namespace Sabberworm\CSS\Value;
 
 class Color extends CSSFunction {
 
-	public function __construct($aColor) {
-		parent::__construct(implode('', array_keys($aColor)), $aColor);
+	public function __construct($aColor, $iLineNum = 0) {
+		parent::__construct(implode('', array_keys($aColor)), $aColor, ',', $iLineNum);
 	}
 
 	public function getColor() {

--- a/lib/Sabberworm/CSS/Value/PrimitiveValue.php
+++ b/lib/Sabberworm/CSS/Value/PrimitiveValue.php
@@ -3,8 +3,8 @@
 namespace Sabberworm\CSS\Value;
 
 abstract class PrimitiveValue extends Value {
-    public function __construct($iLineNum = 0) {
-        parent::__construct($iLineNum);
+    public function __construct($iLineNo = 0) {
+        parent::__construct($iLineNo);
     }
 
 }

--- a/lib/Sabberworm/CSS/Value/PrimitiveValue.php
+++ b/lib/Sabberworm/CSS/Value/PrimitiveValue.php
@@ -3,5 +3,8 @@
 namespace Sabberworm\CSS\Value;
 
 abstract class PrimitiveValue extends Value {
-	
+    public function __construct($iLineNum = 0) {
+        parent::__construct($iLineNum);
+    }
+
 }

--- a/lib/Sabberworm/CSS/Value/RuleValueList.php
+++ b/lib/Sabberworm/CSS/Value/RuleValueList.php
@@ -3,9 +3,7 @@
 namespace Sabberworm\CSS\Value;
 
 class RuleValueList extends ValueList {
-
-	public function __construct($sSeparator = ',') {
-		parent::__construct(array(), $sSeparator);
+	public function __construct($sSeparator = ',', $iLineNum = 0) {
+		parent::__construct(array(), $sSeparator, $iLineNum);
 	}
-
 }

--- a/lib/Sabberworm/CSS/Value/RuleValueList.php
+++ b/lib/Sabberworm/CSS/Value/RuleValueList.php
@@ -3,7 +3,7 @@
 namespace Sabberworm\CSS\Value;
 
 class RuleValueList extends ValueList {
-	public function __construct($sSeparator = ',', $iLineNum = 0) {
-		parent::__construct(array(), $sSeparator, $iLineNum);
+	public function __construct($sSeparator = ',', $iLineNo = 0) {
+		parent::__construct(array(), $sSeparator, $iLineNo);
 	}
 }

--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -22,7 +22,7 @@ class Size extends PrimitiveValue {
 	/**
 	 * @return int
 	 */
-	public function getLineNum()
+	public function getLineNo()
 	{
 		return $this->iLineNum;
 	}

--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -19,14 +19,6 @@ class Size extends PrimitiveValue {
 		$this->bIsColorComponent = $bIsColorComponent;
 	}
 
-	/**
-	 * @return int
-	 */
-	public function getLineNo()
-	{
-		return $this->iLineNum;
-	}
-
 	public function setUnit($sUnit) {
 		$this->sUnit = $sUnit;
 	}

--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -12,10 +12,19 @@ class Size extends PrimitiveValue {
 	private $sUnit;
 	private $bIsColorComponent;
 
-	public function __construct($fSize, $sUnit = null, $bIsColorComponent = false) {
+	public function __construct($fSize, $sUnit = null, $bIsColorComponent = false, $iLineNum = 0) {
+		parent::__construct($iLineNum);
 		$this->fSize = floatval($fSize);
 		$this->sUnit = $sUnit;
 		$this->bIsColorComponent = $bIsColorComponent;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getLineNum()
+	{
+		return $this->iLineNum;
 	}
 
 	public function setUnit($sUnit) {

--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -12,8 +12,8 @@ class Size extends PrimitiveValue {
 	private $sUnit;
 	private $bIsColorComponent;
 
-	public function __construct($fSize, $sUnit = null, $bIsColorComponent = false, $iLineNum = 0) {
-		parent::__construct($iLineNum);
+	public function __construct($fSize, $sUnit = null, $bIsColorComponent = false, $iLineNo = 0) {
+		parent::__construct($iLineNo);
 		$this->fSize = floatval($fSize);
 		$this->sUnit = $sUnit;
 		$this->bIsColorComponent = $bIsColorComponent;

--- a/lib/Sabberworm/CSS/Value/URL.php
+++ b/lib/Sabberworm/CSS/Value/URL.php
@@ -7,8 +7,8 @@ class URL extends PrimitiveValue {
 
 	private $oURL;
 
-	public function __construct(CSSString $oURL, $iLineNum = 0) {
-		parent::__construct($iLineNum);
+	public function __construct(CSSString $oURL, $iLineNo = 0) {
+		parent::__construct($iLineNo);
 		$this->oURL = $oURL;
 	}
 

--- a/lib/Sabberworm/CSS/Value/URL.php
+++ b/lib/Sabberworm/CSS/Value/URL.php
@@ -7,7 +7,8 @@ class URL extends PrimitiveValue {
 
 	private $oURL;
 
-	public function __construct(CSSString $oURL) {
+	public function __construct(CSSString $oURL, $iLineNum = 0) {
+		parent::__construct($iLineNum);
 		$this->oURL = $oURL;
 	}
 

--- a/lib/Sabberworm/CSS/Value/Value.php
+++ b/lib/Sabberworm/CSS/Value/Value.php
@@ -19,6 +19,14 @@ abstract class Value implements Renderable {
         return $this->iLineNum;
     }
 
+    /**
+     * @param int $iLineNum
+     */
+    public function setLineNo($iLineNum = 0)
+    {
+        $this->iLineNum = $iLineNum;
+    }
+
     //Methods are commented out because re-declaring them here is a fatal error in PHP < 5.3.9
 	//public abstract function __toString();
 	//public abstract function render(\Sabberworm\CSS\OutputFormat $oOutputFormat);

--- a/lib/Sabberworm/CSS/Value/Value.php
+++ b/lib/Sabberworm/CSS/Value/Value.php
@@ -18,13 +18,6 @@ abstract class Value implements Renderable {
         return $this->iLineNo;
     }
 
-    /**
-     * @param int $iLineNo
-     */
-    public function setLineNo($iLineNo = 0) {
-        $this->iLineNo = $iLineNo;
-    }
-
     //Methods are commented out because re-declaring them here is a fatal error in PHP < 5.3.9
 	//public abstract function __toString();
 	//public abstract function render(\Sabberworm\CSS\OutputFormat $oOutputFormat);

--- a/lib/Sabberworm/CSS/Value/Value.php
+++ b/lib/Sabberworm/CSS/Value/Value.php
@@ -5,10 +5,10 @@ namespace Sabberworm\CSS\Value;
 use Sabberworm\CSS\Renderable;
 
 abstract class Value implements Renderable {
-    protected $iLineNum;
+    protected $iLineNo;
 
-    public function __construct($iLineNum = 0) {
-        $this->iLineNum = $iLineNum;
+    public function __construct($iLineNo = 0) {
+        $this->iLineNo = $iLineNo;
     }
     
     /**
@@ -16,15 +16,15 @@ abstract class Value implements Renderable {
      */
     public function getLineNo()
     {
-        return $this->iLineNum;
+        return $this->iLineNo;
     }
 
     /**
-     * @param int $iLineNum
+     * @param int $iLineNo
      */
-    public function setLineNo($iLineNum = 0)
+    public function setLineNo($iLineNo = 0)
     {
-        $this->iLineNum = $iLineNum;
+        $this->iLineNo = $iLineNo;
     }
 
     //Methods are commented out because re-declaring them here is a fatal error in PHP < 5.3.9

--- a/lib/Sabberworm/CSS/Value/Value.php
+++ b/lib/Sabberworm/CSS/Value/Value.php
@@ -5,7 +5,21 @@ namespace Sabberworm\CSS\Value;
 use Sabberworm\CSS\Renderable;
 
 abstract class Value implements Renderable {
-	//Methods are commented out because re-declaring them here is a fatal error in PHP < 5.3.9
+    protected $iLineNum;
+
+    public function __construct($iLineNum = 0) {
+        $this->iLineNum = $iLineNum;
+    }
+    
+    /**
+     * @return int
+     */
+    public function getLineNum()
+    {
+        return $this->iLineNum;
+    }
+
+    //Methods are commented out because re-declaring them here is a fatal error in PHP < 5.3.9
 	//public abstract function __toString();
 	//public abstract function render(\Sabberworm\CSS\OutputFormat $oOutputFormat);
 }

--- a/lib/Sabberworm/CSS/Value/Value.php
+++ b/lib/Sabberworm/CSS/Value/Value.php
@@ -14,7 +14,7 @@ abstract class Value implements Renderable {
     /**
      * @return int
      */
-    public function getLineNum()
+    public function getLineNo()
     {
         return $this->iLineNum;
     }

--- a/lib/Sabberworm/CSS/Value/Value.php
+++ b/lib/Sabberworm/CSS/Value/Value.php
@@ -14,16 +14,14 @@ abstract class Value implements Renderable {
     /**
      * @return int
      */
-    public function getLineNo()
-    {
+    public function getLineNo() {
         return $this->iLineNo;
     }
 
     /**
      * @param int $iLineNo
      */
-    public function setLineNo($iLineNo = 0)
-    {
+    public function setLineNo($iLineNo = 0) {
         $this->iLineNo = $iLineNo;
     }
 

--- a/lib/Sabberworm/CSS/Value/ValueList.php
+++ b/lib/Sabberworm/CSS/Value/ValueList.php
@@ -7,8 +7,8 @@ abstract class ValueList extends Value {
 	protected $aComponents;
 	protected $sSeparator;
 
-	public function __construct($aComponents = array(), $sSeparator = ',', $iLineNum = 0) {
-		parent::__construct($iLineNum);
+	public function __construct($aComponents = array(), $sSeparator = ',', $iLineNo = 0) {
+		parent::__construct($iLineNo);
 		if (!is_array($aComponents)) {
 			$aComponents = array($aComponents);
 		}

--- a/lib/Sabberworm/CSS/Value/ValueList.php
+++ b/lib/Sabberworm/CSS/Value/ValueList.php
@@ -7,7 +7,8 @@ abstract class ValueList extends Value {
 	protected $aComponents;
 	protected $sSeparator;
 
-	public function __construct($aComponents = array(), $sSeparator = ',') {
+	public function __construct($aComponents = array(), $sSeparator = ',', $iLineNum = 0) {
+		parent::__construct($iLineNum);
 		if (!is_array($aComponents)) {
 			$aComponents = array($aComponents);
 		}

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -492,4 +492,16 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 		$this->assertEquals($aExpected, $aActual);
 	}
 
+	/**
+	 * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
+	 */
+	public function testUnexpectedTokenExceptionLineNo() {
+		$oParser = new Parser("\ntest: 1;", Settings::create()->beStrict());
+		try {
+			$oParser->parse();
+		} catch (UnexpectedTokenException $e) {
+			$this->assertSame($e->getLineNo(), 2);
+			throw $e;
+		}
+	}
 }

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -52,21 +52,21 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
 				$this->assertSame('red', $oColor);
 				$aColorRule = $oRuleSet->getRules('background-');
 				$oColor = $aColorRule[0]->getValue();
-				$this->assertEquals(array('r' => new Size(35.0, null, true), 'g' => new Size(35.0, null, true), 'b' => new Size(35.0, null, true)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(35.0, null, true, 5), 'g' => new Size(35.0, null, true, 5), 'b' => new Size(35.0, null, true, 5)), $oColor->getColor());
 				$aColorRule = $oRuleSet->getRules('border-color');
 				$oColor = $aColorRule[0]->getValue();
-				$this->assertEquals(array('r' => new Size(10.0, null, true), 'g' => new Size(100.0, null, true), 'b' => new Size(230.0, null, true)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(10.0, null, true, 2), 'g' => new Size(100.0, null, true, 2), 'b' => new Size(230.0, null, true, 2)), $oColor->getColor());
 				$oColor = $aColorRule[1]->getValue();
-				$this->assertEquals(array('r' => new Size(10.0, null, true), 'g' => new Size(100.0, null, true), 'b' => new Size(231.0, null, true), 'a' => new Size("0000.3", null, true)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(10.0, null, true, 3), 'g' => new Size(100.0, null, true, 3), 'b' => new Size(231.0, null, true, 3), 'a' => new Size("0000.3", null, true, 3)), $oColor->getColor());
 				$aColorRule = $oRuleSet->getRules('outline-color');
 				$oColor = $aColorRule[0]->getValue();
-				$this->assertEquals(array('r' => new Size(34.0, null, true), 'g' => new Size(34.0, null, true), 'b' => new Size(34.0, null, true)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(34.0, null, true, 4), 'g' => new Size(34.0, null, true, 4), 'b' => new Size(34.0, null, true, 4)), $oColor->getColor());
 			} else if($sSelector === '#yours') {
 				$aColorRule = $oRuleSet->getRules('background-color');
 				$oColor = $aColorRule[0]->getValue();
-				$this->assertEquals(array('h' => new Size(220.0, null, true), 's' => new Size(10.0, '%', true), 'l' => new Size(220.0, '%', true)), $oColor->getColor());
+				$this->assertEquals(array('h' => new Size(220.0, null, true, 9), 's' => new Size(10.0, '%', true, 9), 'l' => new Size(220.0, '%', true, 9)), $oColor->getColor());
 				$oColor = $aColorRule[1]->getValue();
-				$this->assertEquals(array('h' => new Size(220.0, null, true), 's' => new Size(10.0, '%', true), 'l' => new Size(220.0, '%', true), 'a' => new Size(0000.3, null, true)), $oColor->getColor());
+				$this->assertEquals(array('h' => new Size(220.0, null, true, 10), 's' => new Size(10.0, '%', true, 10), 'l' => new Size(220.0, '%', true, 10), 'a' => new Size(0000.3, null, true, 10)), $oColor->getColor());
 			}
 		}
 		foreach ($oDoc->getAllValues('color') as $sColor) {

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -52,27 +52,21 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
 				$this->assertSame('red', $oColor);
 				$aColorRule = $oRuleSet->getRules('background-');
 				$oColor = $aColorRule[0]->getValue();
-				$oColor->setLineNo(0);
-				$this->assertEquals(array('r' => new Size(35.0, null, true), 'g' => new Size(35.0, null, true), 'b' => new Size(35.0, null, true)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(35.0, null, true, $oColor->getLineNo()), 'g' => new Size(35.0, null, true, $oColor->getLineNo()), 'b' => new Size(35.0, null, true, $oColor->getLineNo())), $oColor->getColor());
 				$aColorRule = $oRuleSet->getRules('border-color');
 				$oColor = $aColorRule[0]->getValue();
-				$oColor->setLineNo(0);
-				$this->assertEquals(array('r' => new Size(10.0, null, true), 'g' => new Size(100.0, null, true), 'b' => new Size(230.0, null, true)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(10.0, null, true, $oColor->getLineNo()), 'g' => new Size(100.0, null, true, $oColor->getLineNo()), 'b' => new Size(230.0, null, true, $oColor->getLineNo())), $oColor->getColor());
 				$oColor = $aColorRule[1]->getValue();
-				$oColor->setLineNo(0);
-				$this->assertEquals(array('r' => new Size(10.0, null, true), 'g' => new Size(100.0, null, true), 'b' => new Size(231.0, null, true), 'a' => new Size("0000.3", null, true)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(10.0, null, true, $oColor->getLineNo()), 'g' => new Size(100.0, null, true, $oColor->getLineNo()), 'b' => new Size(231.0, null, true, $oColor->getLineNo()), 'a' => new Size("0000.3", null, true, $oColor->getLineNo())), $oColor->getColor());
 				$aColorRule = $oRuleSet->getRules('outline-color');
 				$oColor = $aColorRule[0]->getValue();
-				$oColor->setLineNo(0);
-				$this->assertEquals(array('r' => new Size(34.0, null, true), 'g' => new Size(34.0, null, true), 'b' => new Size(34.0, null, true)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(34.0, null, true, $oColor->getLineNo()), 'g' => new Size(34.0, null, true, $oColor->getLineNo()), 'b' => new Size(34.0, null, true, $oColor->getLineNo())), $oColor->getColor());
 			} else if($sSelector === '#yours') {
 				$aColorRule = $oRuleSet->getRules('background-color');
 				$oColor = $aColorRule[0]->getValue();
-				$oColor->setLineNo(0);
-				$this->assertEquals(array('h' => new Size(220.0, null, true), 's' => new Size(10.0, '%', true), 'l' => new Size(220.0, '%', true)), $oColor->getColor());
+				$this->assertEquals(array('h' => new Size(220.0, null, true, $oColor->getLineNo()), 's' => new Size(10.0, '%', true, $oColor->getLineNo()), 'l' => new Size(220.0, '%', true, $oColor->getLineNo())), $oColor->getColor());
 				$oColor = $aColorRule[1]->getValue();
-				$oColor->setLineNo(0);
-				$this->assertEquals(array('h' => new Size(220.0, null, true), 's' => new Size(10.0, '%', true), 'l' => new Size(220.0, '%', true), 'a' => new Size(0000.3, null, true)), $oColor->getColor());
+				$this->assertEquals(array('h' => new Size(220.0, null, true, $oColor->getLineNo()), 's' => new Size(10.0, '%', true, $oColor->getLineNo()), 'l' => new Size(220.0, '%', true, $oColor->getLineNo()), 'a' => new Size(0000.3, null, true, $oColor->getLineNo())), $oColor->getColor());
 			}
 		}
 		foreach ($oDoc->getAllValues('color') as $sColor) {

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -52,21 +52,21 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
 				$this->assertSame('red', $oColor);
 				$aColorRule = $oRuleSet->getRules('background-');
 				$oColor = $aColorRule[0]->getValue();
-				$this->assertEquals(array('r' => new Size(35.0, null, true, 5), 'g' => new Size(35.0, null, true, 5), 'b' => new Size(35.0, null, true, 5)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(35.0, null, true), 'g' => new Size(35.0, null, true), 'b' => new Size(35.0, null, true)), $oColor->getColor());
 				$aColorRule = $oRuleSet->getRules('border-color');
 				$oColor = $aColorRule[0]->getValue();
-				$this->assertEquals(array('r' => new Size(10.0, null, true, 2), 'g' => new Size(100.0, null, true, 2), 'b' => new Size(230.0, null, true, 2)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(10.0, null, true), 'g' => new Size(100.0, null, true), 'b' => new Size(230.0, null, true)), $oColor->getColor());
 				$oColor = $aColorRule[1]->getValue();
-				$this->assertEquals(array('r' => new Size(10.0, null, true, 3), 'g' => new Size(100.0, null, true, 3), 'b' => new Size(231.0, null, true, 3), 'a' => new Size("0000.3", null, true, 3)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(10.0, null, true), 'g' => new Size(100.0, null, true), 'b' => new Size(231.0, null, true), 'a' => new Size("0000.3", null, true)), $oColor->getColor());
 				$aColorRule = $oRuleSet->getRules('outline-color');
 				$oColor = $aColorRule[0]->getValue();
-				$this->assertEquals(array('r' => new Size(34.0, null, true, 4), 'g' => new Size(34.0, null, true, 4), 'b' => new Size(34.0, null, true, 4)), $oColor->getColor());
+				$this->assertEquals(array('r' => new Size(34.0, null, true), 'g' => new Size(34.0, null, true), 'b' => new Size(34.0, null, true)), $oColor->getColor());
 			} else if($sSelector === '#yours') {
 				$aColorRule = $oRuleSet->getRules('background-color');
 				$oColor = $aColorRule[0]->getValue();
-				$this->assertEquals(array('h' => new Size(220.0, null, true, 9), 's' => new Size(10.0, '%', true, 9), 'l' => new Size(220.0, '%', true, 9)), $oColor->getColor());
+				$this->assertEquals(array('h' => new Size(220.0, null, true), 's' => new Size(10.0, '%', true), 'l' => new Size(220.0, '%', true)), $oColor->getColor());
 				$oColor = $aColorRule[1]->getValue();
-				$this->assertEquals(array('h' => new Size(220.0, null, true, 10), 's' => new Size(10.0, '%', true, 10), 'l' => new Size(220.0, '%', true, 10), 'a' => new Size(0000.3, null, true, 10)), $oColor->getColor());
+				$this->assertEquals(array('h' => new Size(220.0, null, true), 's' => new Size(10.0, '%', true), 'l' => new Size(220.0, '%', true), 'a' => new Size(0000.3, null, true)), $oColor->getColor());
 			}
 		}
 		foreach ($oDoc->getAllValues('color') as $sColor) {

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -52,20 +52,26 @@ class ParserTest extends \PHPUnit_Framework_TestCase {
 				$this->assertSame('red', $oColor);
 				$aColorRule = $oRuleSet->getRules('background-');
 				$oColor = $aColorRule[0]->getValue();
+				$oColor->setLineNo(0);
 				$this->assertEquals(array('r' => new Size(35.0, null, true), 'g' => new Size(35.0, null, true), 'b' => new Size(35.0, null, true)), $oColor->getColor());
 				$aColorRule = $oRuleSet->getRules('border-color');
 				$oColor = $aColorRule[0]->getValue();
+				$oColor->setLineNo(0);
 				$this->assertEquals(array('r' => new Size(10.0, null, true), 'g' => new Size(100.0, null, true), 'b' => new Size(230.0, null, true)), $oColor->getColor());
 				$oColor = $aColorRule[1]->getValue();
+				$oColor->setLineNo(0);
 				$this->assertEquals(array('r' => new Size(10.0, null, true), 'g' => new Size(100.0, null, true), 'b' => new Size(231.0, null, true), 'a' => new Size("0000.3", null, true)), $oColor->getColor());
 				$aColorRule = $oRuleSet->getRules('outline-color');
 				$oColor = $aColorRule[0]->getValue();
+				$oColor->setLineNo(0);
 				$this->assertEquals(array('r' => new Size(34.0, null, true), 'g' => new Size(34.0, null, true), 'b' => new Size(34.0, null, true)), $oColor->getColor());
 			} else if($sSelector === '#yours') {
 				$aColorRule = $oRuleSet->getRules('background-color');
 				$oColor = $aColorRule[0]->getValue();
+				$oColor->setLineNo(0);
 				$this->assertEquals(array('h' => new Size(220.0, null, true), 's' => new Size(10.0, '%', true), 'l' => new Size(220.0, '%', true)), $oColor->getColor());
 				$oColor = $aColorRule[1]->getValue();
+				$oColor->setLineNo(0);
 				$this->assertEquals(array('h' => new Size(220.0, null, true), 's' => new Size(10.0, '%', true), 'l' => new Size(220.0, '%', true), 'a' => new Size(0000.3, null, true)), $oColor->getColor());
 			}
 		}

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -443,7 +443,7 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 	function testLineNumbersParsing() {
 		$oDoc = $this->parsedStructureForFile('line-numbers');
 		// array key is the expected line number
-		$aExpected = [
+		$aExpected = array(
 			1 => ['Sabberworm\CSS\Property\Charset'],
 			3 => ['Sabberworm\CSS\Property\CSSNamespace'],
 			5 => ['Sabberworm\CSS\RuleSet\AtRuleSet'],
@@ -452,9 +452,9 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 			17 => ['Sabberworm\CSS\CSSList\KeyFrame', 18, 20],
 			23 => ['Sabberworm\CSS\Property\Import'],
 			25 => ['Sabberworm\CSS\RuleSet\DeclarationBlock']
-		];
+		);
 
-		$aActual = [];
+		$aActual = array();
 		foreach ($oDoc->getContents() as $oContent) {
 			$aActual[$oContent->getLineNo()] = [get_class($oContent)];
 			if ($oContent instanceof KeyFrame) {
@@ -464,8 +464,8 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 			}
 		}
 
-		$aUrlExpected = [7, 26]; // expected line numbers
-		$aUrlActual = [];
+		$aUrlExpected = array(7, 26); // expected line numbers
+		$aUrlActual = array();
 		foreach ($oDoc->getAllValues() as $oValue) {
 			if ($oValue instanceof URL) {
 				$aUrlActual[] = $oValue->getLineNo();

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -456,7 +456,7 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 
 		$aActual = array();
 		foreach ($oDoc->getContents() as $oContent) {
-			$aActual[$oContent->getLineNo()] = [get_class($oContent)];
+			$aActual[$oContent->getLineNo()] = array(get_class($oContent));
 			if ($oContent instanceof KeyFrame) {
 				foreach ($oContent->getContents() as $block) {
 					$aActual[$oContent->getLineNo()][] = $block->getLineNo();

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -8,6 +8,7 @@ use Sabberworm\CSS\Property\Selector;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
 use Sabberworm\CSS\Property\AtRule;
 use Sabberworm\CSS\Value\URL;
+use Sabberworm\CSS\Value\Color;
 
 class ParserTest extends \PHPUnit_Framework_TestCase {
 
@@ -471,6 +472,22 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 				$aUrlActual[] = $oValue->getLineNo();
 			}
 		}
+
+		// Checking for the multiline color rule lines 27-31
+		$aExpectedColorLines = array(28, 29, 30);
+		$aDeclBlocks = $oDoc->getAllDeclarationBlocks();
+		// Choose the 2nd one
+		$oDeclBlock = $aDeclBlocks[1];
+		$aRules = $oDeclBlock->getRules();
+		// Choose the 2nd one
+		$oColor = $aRules[1]->getValue();
+		$this->assertEquals($aRules[1]->getLineNo(), 27);
+
+		foreach ($oColor->getColor() as $oSize) {
+			$aActualColorLines[] = $oSize->getLineNo();
+		}
+
+		$this->assertEquals($aExpectedColorLines, $aActualColorLines);
 		$this->assertEquals($aUrlExpected, $aUrlActual);
 		$this->assertEquals($aExpected, $aActual);
 	}

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -8,7 +8,7 @@ use Sabberworm\CSS\Property\Selector;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
 use Sabberworm\CSS\Property\AtRule;
 use Sabberworm\CSS\Value\URL;
-use Sabberworm\CSS\Value\Color;
+use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 
 class ParserTest extends \PHPUnit_Framework_TestCase {
 
@@ -481,7 +481,7 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 		$aRules = $oDeclBlock->getRules();
 		// Choose the 2nd one
 		$oColor = $aRules[1]->getValue();
-		$this->assertEquals($aRules[1]->getLineNo(), 27);
+		$this->assertEquals(27, $aRules[1]->getLineNo());
 
 		foreach ($oColor->getColor() as $oSize) {
 			$aActualColorLines[] = $oSize->getLineNo();
@@ -493,14 +493,15 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 	}
 
 	/**
-	 * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
+	 * @expectedException \Sabberworm\CSS\Parsing\UnexpectedTokenException
+	 * Credit: This test by @sabberworm (from https://github.com/sabberworm/PHP-CSS-Parser/pull/105#issuecomment-229643910 )
 	 */
-	public function testUnexpectedTokenExceptionLineNo() {
+	function testUnexpectedTokenExceptionLineNo() {
 		$oParser = new Parser("\ntest: 1;", Settings::create()->beStrict());
 		try {
 			$oParser->parse();
 		} catch (UnexpectedTokenException $e) {
-			$this->assertSame($e->getLineNo(), 2);
+			$this->assertSame(2, $e->getLineNo());
 			throw $e;
 		}
 	}

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -444,14 +444,14 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 		$oDoc = $this->parsedStructureForFile('line-numbers');
 		// array key is the expected line number
 		$aExpected = array(
-			1 => ['Sabberworm\CSS\Property\Charset'],
-			3 => ['Sabberworm\CSS\Property\CSSNamespace'],
-			5 => ['Sabberworm\CSS\RuleSet\AtRuleSet'],
-			11 => ['Sabberworm\CSS\RuleSet\DeclarationBlock'],
+			1 => array('Sabberworm\CSS\Property\Charset'),
+			3 => array('Sabberworm\CSS\Property\CSSNamespace'),
+			5 => array('Sabberworm\CSS\RuleSet\AtRuleSet'),
+			11 => array('Sabberworm\CSS\RuleSet\DeclarationBlock'),
 			// Line Numbers of the inner declaration blocks
-			17 => ['Sabberworm\CSS\CSSList\KeyFrame', 18, 20],
-			23 => ['Sabberworm\CSS\Property\Import'],
-			25 => ['Sabberworm\CSS\RuleSet\DeclarationBlock']
+			17 => array('Sabberworm\CSS\CSSList\KeyFrame', 18, 20),
+			23 => array('Sabberworm\CSS\Property\Import'),
+			25 => array('Sabberworm\CSS\RuleSet\DeclarationBlock')
 		);
 
 		$aActual = array();

--- a/tests/files/line-numbers.css
+++ b/tests/files/line-numbers.css
@@ -1,0 +1,28 @@
+@charset "utf-8"; /* line 3 */
+
+@namespace "http://toto.example.org"; /* line 1 */
+
+@font-face { /* line 5 */
+    font-family: "CrassRoots";
+    src: url("http://example.com/media/cr.ttf")
+}
+
+
+#header { /* line 11 */
+    margin: 10px 2em 1cm 2%;
+    font-family: Verdana, Helvetica, "Gill Sans", sans-serif;
+    color: red !important;
+}
+
+@keyframes mymove {    /* line 17 */
+    from { top: 0px; } /* line 18 */
+
+    to { top: 200px; } /* line 20 */
+}
+
+@IMPORT uRL(test.css); /* line 23 */
+
+body {
+    background: #FFFFFF url("http://somesite.com/images/someimage.gif") repeat top center; /* line 25 */
+    color: rgb(233, 100, 450);
+}

--- a/tests/files/line-numbers.css
+++ b/tests/files/line-numbers.css
@@ -1,10 +1,10 @@
-@charset "utf-8"; /* line 3 */
+@charset "utf-8"; /* line 1 */
 
-@namespace "http://toto.example.org"; /* line 1 */
+@namespace "http://toto.example.org"; /* line 3 */
 
 @font-face { /* line 5 */
     font-family: "CrassRoots";
-    src: url("http://example.com/media/cr.ttf")
+    src: url("http://example.com/media/cr.ttf") /* line 7 */
 }
 
 

--- a/tests/files/line-numbers.css
+++ b/tests/files/line-numbers.css
@@ -24,5 +24,9 @@
 
 body {
     background: #FFFFFF url("http://somesite.com/images/someimage.gif") repeat top center; /* line 25 */
-    color: rgb(233, 100, 450);
+    color: rgb(   /* line 27 */
+            233,  /* line 28 */
+            100,  /* line 29 */
+            450   /* line 30 */
+    );
 }


### PR DESCRIPTION
AMP HTML is a restricted subset of HTML (See https://www.ampproject.org/ for more details) and the AMP PHP Library provide validation and HTML to AMP HTML conversion utilities. We're using the `masterminds/html5-php` library to parse HTML5 and we're using `sabberworm/php-css-parser` to parse the CSS in the [AMP PHP Library](https://github.com/Lullabot/amp-library)

After parsing the CSS parse we report any problems in the CSS (for e.g. `!important` is disallowed in the AMP dialect of HTML, we use the `sabberworm` parser to find all the uses of `!important` for instance)

Now the CSS supplied by the user could be hundreds / thousands of lines long. So its not useful to simply say that `!important` was used and is not allowed. We should be able to say _which line_ the problem occurred.

This pull request adds support for line numbers. Here is how we're using this https://github.com/Lullabot/amp-library/pull/80#issuecomment-222695630
Notice the line numbers reported in the validation errors which coming from code submitted in this PR.

Would greatly appreciate if you had a look and merge it if you believe this feature would be useful. Hopefully the code changes have not missed anything out.

Thanks for this useful library BTW.