### PR TITLE
Primary support for comment parsing

### DIFF
--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -6,17 +6,20 @@ use Sabberworm\CSS\Renderable;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
 use Sabberworm\CSS\RuleSet\RuleSet;
 use Sabberworm\CSS\Property\Selector;
+use Sabberworm\CSS\Comment\Commentable;
 
 /**
  * A CSSList is the most generic container available. Its contents include RuleSet as well as other CSSList objects.
  * Also, it may contain Import and Charset objects stemming from @-rules.
  */
-abstract class CSSList implements Renderable {
+abstract class CSSList implements Renderable, Commentable {
 
+	protected $aComments;
 	protected $aContents;
 	protected $iLineNo;
 
 	public function __construct($iLineNo = 0) {
+		$this->aComments = array();
 		$this->aContents = array();
 		$this->iLineNo = $iLineNo;
 	}
@@ -118,4 +121,26 @@ abstract class CSSList implements Renderable {
 	public function getContents() {
 		return $this->aContents;
 	}
+
+	/**
+	 * @param array $aComments Array of comments.
+	 */
+	public function addComments(array $aComments) {
+		$this->aComments = array_merge($this->aComments, $aComments);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getComments() {
+		return $this->aComments;
+	}
+
+	/**
+	 * @param array $aComments Array containing Comment objects.
+	 */
+	public function setComments(array $aComments) {
+		$this->aComments = $aComments;
+	}
+
 }

--- a/lib/Sabberworm/CSS/Comment/Comment.php
+++ b/lib/Sabberworm/CSS/Comment/Comment.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sabberworm\CSS\Comment;
+
+use Sabberworm\CSS\Renderable;
+
+class Comment implements Renderable {
+	protected $iLineNo;
+	protected $sComment;
+
+	public function __construct($sComment = '', $iLineNo = 0) {
+		$this->sComment = $sComment;
+		$this->iLineNo = $iLineNo;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getComment() {
+		return $this->sComment;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getLineNo() {
+		return $this->iLineNo;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function setComment($sComment) {
+		$this->sComment = $sComment;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function __toString() {
+		return $this->render(new \Sabberworm\CSS\OutputFormat());
+	}
+
+	/**
+	 * @return string
+	 */
+	public function render(\Sabberworm\CSS\OutputFormat $oOutputFormat) {
+		return '/*' . $this->sComment . '*/';
+	}
+
+}

--- a/lib/Sabberworm/CSS/Comment/Commentable.php
+++ b/lib/Sabberworm/CSS/Comment/Commentable.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sabberworm\CSS\Comment;
+
+interface Commentable {
+
+	/**
+	 * @param array $aComments Array of comments.
+	 */
+	public function addComments(array $aComments);
+
+	/**
+	 * @return array
+	 */
+	public function getComments();
+
+	/**
+	 * @param array $aComments Array containing Comment objects.
+	 */
+	public function setComments(array $aComments);
+
+
+}

--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -298,9 +298,9 @@ class Parser {
 	}
 
 	private function parseSelector() {
-		$aComments = $this->consumeWhiteSpace();
+		$aComments = array();
 		$oResult = new DeclarationBlock($this->iLineNo);
-		$oResult->setSelector($this->consumeUntil('{', false, true));
+		$oResult->setSelector($this->consumeUntil('{', false, true, $aComments));
 		$oResult->setComments($aComments);
 		$this->parseRuleSet($oResult);
 		return $oResult;
@@ -608,13 +608,12 @@ class Parser {
 		return $this->iCurrentPosition >= $this->iLength;
 	}
 
-	private function consumeUntil($aEnd, $bIncludeEnd = false, $consumeEnd = false) {
+	private function consumeUntil($aEnd, $bIncludeEnd = false, $consumeEnd = false, array &$comments = array()) {
 		$aEnd = is_array($aEnd) ? $aEnd : array($aEnd);
 		$out = '';
 		$start = $this->iCurrentPosition;
 
 		while (($char = $this->consume(1)) !== '') {
-			$this->consumeComment();
 			if (in_array($char, $aEnd)) {
 				if ($bIncludeEnd) {
 					$out .= $char;
@@ -624,6 +623,9 @@ class Parser {
 				return $out;
 			}
 			$out .= $char;
+			if ($comment = $this->consumeComment()) {
+				$comments[] = $comment;
+			}
 		}
 
 		$this->iCurrentPosition = $start;

--- a/lib/Sabberworm/CSS/Property/AtRule.php
+++ b/lib/Sabberworm/CSS/Property/AtRule.php
@@ -3,8 +3,9 @@
 namespace Sabberworm\CSS\Property;
 
 use Sabberworm\CSS\Renderable;
+use Sabberworm\CSS\Comment\Commentable;
 
-interface AtRule extends Renderable {
+interface AtRule extends Renderable, Commentable {
 	const BLOCK_RULES = 'media/document/supports/region-style/font-feature-values';
 	// Since there are more set rules than block rules, we’re whitelisting the block rules and have anything else be treated as a set rule.
 	const SET_RULES = 'font-face/counter-style/page/swash/styleset/annotation'; //…and more font-specific ones (to be used inside font-feature-values)

--- a/lib/Sabberworm/CSS/Property/CSSNamespace.php
+++ b/lib/Sabberworm/CSS/Property/CSSNamespace.php
@@ -9,11 +9,13 @@ class CSSNamespace implements AtRule {
 	private $mUrl;
 	private $sPrefix;
 	private $iLineNo;
+	protected $aComments;
 	
 	public function __construct($mUrl, $sPrefix = null, $iLineNo = 0) {
 		$this->mUrl = $mUrl;
 		$this->sPrefix = $sPrefix;
 		$this->iLineNo = $iLineNo;
+		$this->aComments = array();
 	}
 
 	/**
@@ -57,5 +59,17 @@ class CSSNamespace implements AtRule {
 			array_unshift($aResult, $this->sPrefix);
 		}
 		return $aResult;
+	}
+
+	public function addComments(array $aComments) {
+		$this->aComments = array_merge($this->aComments, $aComments);
+	}
+
+	public function getComments() {
+		return $this->aComments;
+	}
+
+	public function setComments(array $aComments) {
+		$this->aComments = $aComments;
 	}
 }

--- a/lib/Sabberworm/CSS/Property/Charset.php
+++ b/lib/Sabberworm/CSS/Property/Charset.php
@@ -13,10 +13,12 @@ class Charset implements AtRule {
 
 	private $sCharset;
 	protected $iLineNo;
+	protected $aComment;
 
 	public function __construct($sCharset, $iLineNo = 0) {
 		$this->sCharset = $sCharset;
 		$this->iLineNo = $iLineNo;
+		$this->aComments = array();
 	}
 
 	/**
@@ -48,5 +50,17 @@ class Charset implements AtRule {
 
 	public function atRuleArgs() {
 		return $this->sCharset;
+	}
+
+	public function addComments(array $aComments) {
+		$this->aComments = array_merge($this->aComments, $aComments);
+	}
+
+	public function getComments() {
+		return $this->aComments;
+	}
+
+	public function setComments(array $aComments) {
+		$this->aComments = $aComments;
 	}
 }

--- a/lib/Sabberworm/CSS/Property/Import.php
+++ b/lib/Sabberworm/CSS/Property/Import.php
@@ -11,11 +11,13 @@ class Import implements AtRule {
 	private $oLocation;
 	private $sMediaQuery;
 	protected $iLineNo;
+	protected $aComments;
 	
 	public function __construct(URL $oLocation, $sMediaQuery, $iLineNo = 0) {
 		$this->oLocation = $oLocation;
 		$this->sMediaQuery = $sMediaQuery;
 		$this->iLineNo = $iLineNo;
+		$this->aComments = array();
 	}
 
 	/**
@@ -51,5 +53,17 @@ class Import implements AtRule {
 			array_push($aResult, $this->sMediaQuery);
 		}
 		return $aResult;
+	}
+
+	public function addComments(array $aComments) {
+		$this->aComments = array_merge($this->aComments, $aComments);
+	}
+
+	public function getComments() {
+		return $this->aComments;
+	}
+
+	public function setComments(array $aComments) {
+		$this->aComments = $aComments;
 	}
 }

--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -5,23 +5,26 @@ namespace Sabberworm\CSS\Rule;
 use Sabberworm\CSS\Renderable;
 use Sabberworm\CSS\Value\RuleValueList;
 use Sabberworm\CSS\Value\Value;
+use Sabberworm\CSS\Comment\Commentable;
 
 /**
  * RuleSets contains Rule objects which always have a key and a value.
  * In CSS, Rules are expressed as follows: “key: value[0][0] value[0][1], value[1][0] value[1][1];”
  */
-class Rule implements Renderable {
+class Rule implements Renderable, Commentable {
 
 	private $sRule;
 	private $mValue;
 	private $bIsImportant;
 	protected $iLineNo;
+	protected $aComments;
 
 	public function __construct($sRule, $iLineNo = 0) {
 		$this->sRule = $sRule;
 		$this->mValue = null;
 		$this->bIsImportant = false;
 		$this->iLineNo = $iLineNo;
+		$this->aComments = array();
 	}
 
 	/**
@@ -151,6 +154,27 @@ class Rule implements Renderable {
 		}
 		$sResult .= ';';
 		return $sResult;
+	}
+
+	/**
+	 * @param array $aComments Array of comments.
+	 */
+	public function addComments(array $aComments) {
+		$this->aComments = array_merge($this->aComments, $aComments);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getComments() {
+		return $this->aComments;
+	}
+
+	/**
+	 * @param array $aComments Array containing Comment objects.
+	 */
+	public function setComments(array $aComments) {
+		$this->aComments = $aComments;
 	}
 
 }

--- a/lib/Sabberworm/CSS/RuleSet/RuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/RuleSet.php
@@ -4,19 +4,22 @@ namespace Sabberworm\CSS\RuleSet;
 
 use Sabberworm\CSS\Rule\Rule;
 use Sabberworm\CSS\Renderable;
+use Sabberworm\CSS\Comment\Commentable;
 
 /**
  * RuleSet is a generic superclass denoting rules. The typical example for rule sets are declaration block.
  * However, unknown At-Rules (like @font-face) are also rule sets.
  */
-abstract class RuleSet implements Renderable {
+abstract class RuleSet implements Renderable, Commentable {
 
 	private $aRules;
 	protected $iLineNo;
+	protected $aComments;
 
 	public function __construct($iLineNo = 0) {
 		$this->aRules = array();
 		$this->iLineNo = $iLineNo;
+		$this->aComments = array();
 	}
 
 	/**
@@ -123,6 +126,27 @@ abstract class RuleSet implements Renderable {
 		}
 
 		return $oOutputFormat->removeLastSemicolon($sResult);
+	}
+
+	/**
+	 * @param array $aComments Array of comments.
+	 */
+	public function addComments(array $aComments) {
+		$this->aComments = array_merge($this->aComments, $aComments);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getComments() {
+		return $this->aComments;
+	}
+
+	/**
+	 * @param array $aComments Array containing Comment objects.
+	 */
+	public function setComments(array $aComments) {
+		$this->aComments = $aComments;
 	}
 
 }

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -542,6 +542,30 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 		$fooBarComments = $mediaRules[0]->getComments();
 		$this->assertCount(1, $fooBarComments);
 		$this->assertEquals("* Number 10 *", $fooBarComments[0]->getComment());
+
+		// Media -> declaration -> rule.
+		$fooBarRules = $mediaRules[0]->getRules();
+		$fooBarChildComments = $fooBarRules[0]->getComments();
+		$this->assertCount(1, $fooBarChildComments);
+		$this->assertEquals("* Number 10b *", $fooBarChildComments[0]->getComment());
 	}
 
+	function testFlatCommentExtracting() {
+		$parser = new Parser('div {/*Find Me!*/left:10px; text-align:left;}');
+		$doc = $parser->parse();
+		$contents = $doc->getContents();
+		$divRules = $contents[0]->getRules();
+		$comments = $divRules[0]->getComments();
+		$this->assertCount(1, $comments);
+		$this->assertEquals("Find Me!", $comments[0]->getComment());
+	}
+
+	function testTopLevelCommentExtracting() {
+		$parser = new Parser('/*Find Me!*/div {left:10px; text-align:left;}');
+		$doc = $parser->parse();
+		$contents = $doc->getContents();
+		$comments = $contents[0]->getComments();
+		$this->assertCount(1, $comments);
+		$this->assertEquals("Find Me!", $comments[0]->getComment());
+	}
 }

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -505,4 +505,43 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 			throw $e;
 		}
 	}
+
+	/**
+	 * @depends testFiles
+	 */
+	function testCommentExtracting() {
+		$oDoc = $this->parsedStructureForFile('comments');
+		$aNodes = $oDoc->getContents();
+
+		// Import property.
+		$importComments = $aNodes[0]->getComments();
+		$this->assertCount(1, $importComments);
+		$this->assertEquals("*\n * Comments Hell.\n ", $importComments[0]->getComment());
+
+		// Declaration block.
+		$fooBarBlock = $aNodes[1];
+		$fooBarBlockComments = $fooBarBlock->getComments();
+		// TODO Support comments in selectors.
+		// $this->assertCount(2, $fooBarBlockComments);
+		// $this->assertEquals("* Number 4 *", $fooBarBlockComments[0]->getComment());
+		// $this->assertEquals("* Number 5 *", $fooBarBlockComments[1]->getComment());
+
+		// Declaration rules.
+		$fooBarRules = $fooBarBlock->getRules();
+		$fooBarRule = $fooBarRules[0];
+		$fooBarRuleComments = $fooBarRule->getComments();
+		$this->assertCount(1, $fooBarRuleComments);
+		$this->assertEquals(" Number 6 ", $fooBarRuleComments[0]->getComment());
+
+		// Media property.
+		$mediaComments = $aNodes[2]->getComments();
+		$this->assertCount(0, $mediaComments);
+
+		// Media children.
+		$mediaRules = $aNodes[2]->getContents();
+		$fooBarComments = $mediaRules[0]->getComments();
+		$this->assertCount(1, $fooBarComments);
+		$this->assertEquals("* Number 10 *", $fooBarComments[0]->getComment());
+	}
+
 }

--- a/tests/files/comments.css
+++ b/tests/files/comments.css
@@ -10,6 +10,7 @@
 @media /* Number 8 */screen /* Number 9 */{
     /** Number 10 **/
     #foo.bar {
+        /** Number 10b **/
         position: absolute;/**/
     }
 }


### PR DESCRIPTION
The following patch is adding primary support to parsing comments, it does not try to do everything and it does not include the render part (as we don't need it) but hopefully it'll be useful to others.

In short, for the most generic cases, it adds the comments preceding a statement to the statement itself. See the test for more info.

X-ref: #38