### PR TITLE
Support for IE hack parsing in lenient mode

### DIFF
--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -15,12 +15,14 @@ class Rule implements Renderable {
 	private $sRule;
 	private $mValue;
 	private $bIsImportant;
+	private $aIeHack;
 	protected $iLineNo;
 
 	public function __construct($sRule, $iLineNo = 0) {
 		$this->sRule = $sRule;
 		$this->mValue = null;
 		$this->bIsImportant = false;
+		$this->aIeHack = array();
 		$this->iLineNo = $iLineNo;
 	}
 
@@ -127,6 +129,18 @@ class Rule implements Renderable {
 		}
 	}
 
+	public function addIeHack($iModifier) {
+		$this->aIeHack[] = $iModifier;
+	}
+
+	public function setIeHack(array $aModifiers) {
+		$this->aIeHack = $aModifiers;
+	}
+
+	public function getIeHack() {
+		return $this->aIeHack;
+	}
+
 	public function setIsImportant($bIsImportant) {
 		$this->bIsImportant = $bIsImportant;
 	}
@@ -145,6 +159,9 @@ class Rule implements Renderable {
 			$sResult .= $this->mValue->render($oOutputFormat);
 		} else {
 			$sResult .= $this->mValue;
+		}
+		if (!empty($this->aIeHack)) {
+			$sResult .= ' \\' . implode('\\', $this->aIeHack);
 		}
 		if ($this->bIsImportant) {
 			$sResult .= ' !important';

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -505,4 +505,18 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 			throw $e;
 		}
 	}
+
+	/**
+	* @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
+	*/
+	function testIeHacksStrictParsing() {
+		// We can't strictly parse IE hacks.
+		$this->parsedStructureForFile('ie-hacks', Settings::create()->beStrict());
+	}
+
+	function testIeHacksParsing() {
+		$oDoc = $this->parsedStructureForFile('ie-hacks', Settings::create()->withLenientParsing(true));
+		$sExpected = 'p {padding-right: .75rem \9;background-image: none \9;color: red \9\0;background-color: red \9\0;background-color: red \9\0 !important;content: "red 	\0";content: "red઼";}';
+		$this->assertEquals($sExpected, $oDoc->render());
+	}
 }

--- a/tests/files/ie-hacks.css
+++ b/tests/files/ie-hacks.css
@@ -1,0 +1,9 @@
+p {
+    padding-right: .75rem \9;
+    background-image: none \9;
+    color:red\9\0;
+    background-color:red \9 \0;
+    background-color:red \9 \0 !important;
+    content: "red \9\0";
+    content: "red\0abc";
+}


### PR DESCRIPTION
For your consideration. This allows for \0 and \9 to remain as they are intended. And will throw an exception when they are found in strict mode. Again, that to be able to parse Bootstrap 4.