### PR TITLE
Consume expression to indicate how many characters to look ahead

### DIFF
--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -265,7 +265,7 @@ class Parser {
 			if (preg_match('/[0-9a-fA-F]/Su', $this->peek()) === 0) {
 				return $this->consume(1);
 			}
-			$sUnicode = $this->consumeExpression('/^[0-9a-fA-F]{1,6}/u');
+			$sUnicode = $this->consumeExpression('/^[0-9a-fA-F]{1,6}/u', 6);
 			if ($this->strlen($sUnicode) < 6) {
 				//Consume whitespace after incomplete unicode escape
 				if (preg_match('/\\s/isSu', $this->peek())) {
@@ -565,9 +565,10 @@ class Parser {
 		}
 	}
 
-	private function consumeExpression($mExpression) {
+	private function consumeExpression($mExpression, $iMaxLength = null) {
 		$aMatches = null;
-		if (preg_match($mExpression, $this->inputLeft(), $aMatches, PREG_OFFSET_CAPTURE) === 1) {
+		$sInput = $iMaxLength !== null ? $this->peek($iMaxLength) : $this->inputLeft();
+		if (preg_match($mExpression, $sInput, $aMatches, PREG_OFFSET_CAPTURE) === 1) {
 			return $this->consume($aMatches[0][0]);
 		}
 		throw new UnexpectedTokenException($mExpression, $this->peek(5), 'expression', $this->iLineNo);


### PR DESCRIPTION
Where possible consumeExpression should be provided with the maximum number of characters the expression could be made of. This allows for more efficiently peeking for a few characters rather than the entire remaining character map.

This issue was discovered at Moodle when compiling with FontAwesome which uses unicode more heavily. https://tracker.moodle.org/browse/MDL-58646