### PR TITLE
Bug fix in calc parsing when the first operand is a negative value

### DIFF
--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -395,6 +395,12 @@ div {height: -webkit-calc(9 / 16 * 100%) !important;width: -moz-calc(( 50px - 50
 		$this->assertSame($sExpected, $oDoc->render());
 	}
 
+	function testCalcNestedInFile() {
+		$oDoc = $this->parsedStructureForFile('calc-nested', Settings::create()->withMultibyteSupport(true));
+		$sExpected = '.test {font-size: calc(( 3 * 4px ) + -2px);top: calc(200px - calc(20 * 3px));}';
+		$this->assertSame($sExpected, $oDoc->render());
+	}
+
 	function testGridLineNameInFile() {
 		$oDoc = $this->parsedStructureForFile('grid-linename', Settings::create()->withMultibyteSupport(true));
 		$sExpected = "div {grid-template-columns: [linename] 100px;}\nspan {grid-template-columns: [linename1 linename2] 100px;}";

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -390,6 +390,7 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 	function testCalcInFile() {
 		$oDoc = $this->parsedStructureForFile('calc', Settings::create()->withMultibyteSupport(true));
 		$sExpected = 'div {width: calc(100% / 4);}
+div {margin-top: calc(-120% - 4px);}
 div {height: -webkit-calc(9 / 16 * 100%) !important;width: -moz-calc(( 50px - 50% ) * 2);}';
 		$this->assertSame($sExpected, $oDoc->render());
 	}

--- a/tests/files/calc-nested.css
+++ b/tests/files/calc-nested.css
@@ -1,0 +1,4 @@
+.test {
+  font-size: calc((3 * 4px) + -2px);
+  top: calc(200px - calc(20 * 3px));
+}

--- a/tests/files/calc.css
+++ b/tests/files/calc.css
@@ -1,4 +1,5 @@
 div { width: calc(100% / 4); }
+div { margin-top: calc(-120% - 4px); }
 div {
 	height: -webkit-calc(9/16 * 100%)!important;
 	width: -moz-calc((50px - 50%)*2);


### PR DESCRIPTION
These changes fix issues with rules like `calc(-120% - 4px)` and `calc(8px + -50%)`