### PR TITLE
Suppress "Unexpected end of document" in lenient mode

### DIFF
--- a/lib/Sabberworm/CSS/Parser.php
+++ b/lib/Sabberworm/CSS/Parser.php
@@ -113,7 +113,7 @@ class Parser {
 			}
 			$this->consumeWhiteSpace();
 		}
-		if (!$bIsRoot) {
+		if (!$bIsRoot && !$this->oParserSettings->bLenientParsing) {
 			throw new SourceException("Unexpected end of document", $this->iLineNo);
 		}
 	}


### PR DESCRIPTION
Browsers seem to be okay with incomplete documents, they just parse up to the last valid rule. I guess we should do the same in lenient mode.