### PR TITLE
Add splice method to CSSList

### DIFF
--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -176,17 +176,39 @@ abstract class CSSList implements Renderable, Commentable {
 		return $this->iLineNo;
 	}
 
+	/**
+	 * Prepend item to list of contents.
+	 *
+	 * @param object $oItem Item.
+	 */
 	public function prepend($oItem) {
 		array_unshift($this->aContents, $oItem);
 	}
 
+	/**
+	 * Append item to list of contents.
+	 *
+	 * @param object $oItem Item.
+	 */
 	public function append($oItem) {
 		$this->aContents[] = $oItem;
 	}
 
 	/**
+	 * Splice the list of contents.
+	 *
+	 * @param int       $iOffset      Offset.
+	 * @param int       $iLength      Length. Optional.
+	 * @param RuleSet[] $mReplacement Replacement. Optional.
+	 */
+	public function splice($iOffset, $iLength = null, $mReplacement = null) {
+		array_splice($this->aContents, $iOffset, $iLength, $mReplacement);
+	}
+
+	/**
 	 * Removes an item from the CSS list.
 	 * @param RuleSet|Import|Charset|CSSList $oItemToRemove May be a RuleSet (most likely a DeclarationBlock), a Import, a Charset or another CSSList (most likely a MediaQuery)
+	 * @return bool Whether the item was removed.
 	 */
 	public function remove($oItemToRemove) {
 		$iKey = array_search($oItemToRemove, $this->aContents, true);


### PR DESCRIPTION
This PR adds a `splice` method to allow insert/replace one or more items at an arbitrary point in the list. This compliments #149 which added `prepend` and `replace` methods to `CSSList`. 

An example use case for this PR is to extract CSS properties with `!important` qualifiers as separate rules with higher-specificity selectors. Example usage:

https://github.com/ampproject/amp-wp/blob/c92e129333a8518088a37d47594079b537121d70/includes/sanitizers/class-amp-style-sanitizer.php#L1757-L1762

Also adds PhpDoc to surrounding methods.