### PR TITLE
Fix undefined index notice when property lacks value

### DIFF
--- a/lib/Sabberworm/CSS/Value/Value.php
+++ b/lib/Sabberworm/CSS/Value/Value.php
@@ -3,6 +3,7 @@
 namespace Sabberworm\CSS\Value;
 
 use Sabberworm\CSS\Parsing\ParserState;
+use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 use Sabberworm\CSS\Renderable;
 
 abstract class Value implements Renderable {
@@ -56,7 +57,7 @@ abstract class Value implements Renderable {
 			}
 		}
 		if (!isset($aStack[0])) {
-			return null;
+			throw new UnexpectedTokenException(" {$oParserState->peek()} ", $oParserState->peek(1, -1) . $oParserState->peek(2), 'literal', $oParserState->currentLine());
 		}
 		return $aStack[0];
 	}

--- a/lib/Sabberworm/CSS/Value/Value.php
+++ b/lib/Sabberworm/CSS/Value/Value.php
@@ -55,6 +55,9 @@ abstract class Value implements Renderable {
 				array_splice($aStack, $iStartPosition - 1, $iLength * 2 - 1, array($oList));
 			}
 		}
+		if (!isset($aStack[0])) {
+			return null;
+		}
 		return $aStack[0];
 	}
 

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -472,26 +472,63 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 	}
 
 	/**
-	* @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
-	*/
+	 * @expectedException \Sabberworm\CSS\Parsing\UnexpectedTokenException
+	 */
 	function testCharsetFailure1() {
 		$this->parsedStructureForFile('-charset-after-rule', Settings::create()->withLenientParsing(false));
 	}
 
 	/**
-	* @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
-	*/
+	 * @expectedException \Sabberworm\CSS\Parsing\UnexpectedTokenException
+	 */
 	function testCharsetFailure2() {
 		$this->parsedStructureForFile('-charset-in-block', Settings::create()->withLenientParsing(false));
 	}
 
 	/**
-	* @expectedException Sabberworm\CSS\Parsing\SourceException
-	*/
+	 * @expectedException \Sabberworm\CSS\Parsing\SourceException
+	 */
 	function testUnopenedClosingBracketFailure() {
 		$this->parsedStructureForFile('unopened-close-brackets', Settings::create()->withLenientParsing(false));
 	}
 
+	/**
+	 * Ensure that a missing property value raises an exception.
+	 *
+	 * @expectedException \Sabberworm\CSS\Parsing\UnexpectedTokenException
+	 * @covers \Sabberworm\CSS\Value\Value::parseValue()
+	 */
+	function testMissingPropertyValueStrict() {
+		$this->parsedStructureForFile('missing-property-value', Settings::create()->withLenientParsing(false));
+	}
+
+	/**
+	 * Ensure that a missing property value is ignored when in lenient parsing mode.
+	 *
+	 * @covers \Sabberworm\CSS\Value\Value::parseValue()
+	 */
+	function testMissingPropertyValueLenient() {
+		$parsed = $this->parsedStructureForFile('missing-property-value', Settings::create()->withLenientParsing(true));
+		$rulesets = $parsed->getAllRuleSets();
+		$this->assertCount( 1, $rulesets );
+		$block = $rulesets[0];
+		$this->assertTrue( $block instanceof DeclarationBlock );
+		$this->assertEquals( array( 'div' ), $block->getSelectors() );
+		$rules = $block->getRules();
+		$this->assertCount( 1, $rules );
+		$rule = $rules[0];
+		$this->assertEquals( 'display', $rule->getRule() );
+		$this->assertEquals( 'inline-block', $rule->getValue() );
+	}
+
+	/**
+	 * Parse structure for file.
+	 *
+	 * @param string      $sFileName Filename.
+	 * @param null|obJeCt $oSettings Settings.
+	 *
+	 * @return CSSList\Document Parsed document.
+	 */
 	function parsedStructureForFile($sFileName, $oSettings = null) {
 		$sFile = dirname(__FILE__) . '/../../files' . DIRECTORY_SEPARATOR . "$sFileName.css";
 		$oParser = new Parser(file_get_contents($sFile), $oSettings);


### PR DESCRIPTION
Given this CSS:

```css
div {
	display: inline-block;
	display:
}
```

I'm getting a PHP notice:

```
PHP Notice:  Undefined offset: 0 in .../sabberworm/php-css-parser/lib/Sabberworm/CSS/Value/Value.php on line 58
```

This PR fixes that problem by improving the resiliency to bad CSS.