### PR TITLE
Use hhvm 3 explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
     - "7.1"
     - "7.2"
     - "7.3"
-    - hhvm-3.30.3
+    - hhvm-3.30
 sudo: false
 dist: trusty
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
     - "7.1"
     - "7.2"
     - "7.3"
-    - hhvm
+    - hhvm-3.30.3
 sudo: false
 dist: trusty
 matrix:


### PR DESCRIPTION
HHVM 4 on travis won’t run composer. Maybe there’s a workaround for that (install the dependencies using PHP and then use HHVM to run the tests?), but this needs further investigation.