### PR TITLE
Namespace declarations should end in `\\`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
         "codacy/coverage": "^1.4"
     },
     "autoload": {
-        "psr-0": { "Sabberworm\\CSS": "lib/" }
+        "psr-0": { "Sabberworm\\CSS\\": "lib/" }
     }
 }


### PR DESCRIPTION
> Please note namespace declarations should end in `\\` to make sure the autoloader responds exactly.

https://getcomposer.org/doc/04-schema.md#psr-0