### PR TITLE
Bug fix in parsing size units

### DIFF
--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -61,8 +61,7 @@ class Size extends PrimitiveValue {
 				self::$SIZE_UNITS[$iSize][strtolower($val)] = $val;
 			}
 
-			// FIXME: Should we not order the longest units first?
-			ksort(self::$SIZE_UNITS, SORT_NUMERIC);
+			krsort(self::$SIZE_UNITS, SORT_NUMERIC);
 		}
 
 		return self::$SIZE_UNITS;


### PR DESCRIPTION
Size units must be ordered longest first as the FIXME states. Example of an error is parsing `vmin` - it ends up as `vm in`