### PR TITLE
Fix PHP 7.3 warning when using count() on non-array value

### DIFF
--- a/lib/Sabberworm/CSS/Parsing/ParserState.php
+++ b/lib/Sabberworm/CSS/Parsing/ParserState.php
@@ -27,7 +27,9 @@ class ParserState {
 	public function setCharset($sCharset) {
 		$this->sCharset = $sCharset;
 		$this->aText = $this->strsplit($this->sText);
-		$this->iLength = count($this->aText);
+		if( is_array($this->aText) ) {
+			$this->iLength = count($this->aText);
+		}
 	}
 
 	public function getCharset() {


### PR DESCRIPTION
A PHP warning is being raised in PHP 7.3:

> `PHP Warning: count(): Parameter must be an array or an object that implements Countable in .../sabberworm/php-css-parser/lib/Sabberworm/CSS/Parsing/ParserState.php on line 30`

This was reported a couple times in the context of the AMP plugin for WordPress:

* https://wordpress.org/support/topic/php-7-3-9-warning-causing-timeout-on-amp-urls/
* https://github.com/ampproject/amp-wp/issues/1915#issuecomment-539758026

The suggested fix is to ensure that `count()` is only being done with `aText` when it has been populated with an array value.