### PR TITLE
Fix @import's output when there is no media query

### DIFF
--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -115,7 +115,7 @@ abstract class CSSList implements Renderable, Commentable {
 				$sMediaQuery = trim($oParserState->consumeUntil(array(';', ParserState::EOF)));
 			}
 			$oParserState->consumeUntil(array(';', ParserState::EOF), true, true);
-			return new Import($oLocation, $sMediaQuery, $iIdentifierLineNum);
+			return new Import($oLocation, $sMediaQuery ? $sMediaQuery : null, $iIdentifierLineNum);
 		} else if ($sIdentifier === 'charset') {
 			$sCharset = CSSString::parse($oParserState);
 			$oParserState->consumeWhiteSpace();


### PR DESCRIPTION
With the latest changes in parsing the media query for @import statements the media query ends up as the empty string instead of `null` and causes an unnecessary white space in the output.