### PR TITLE
Fix comments being omitted in the middle of a rule

### DIFF
--- a/lib/Sabberworm/CSS/CSSList/CSSList.php
+++ b/lib/Sabberworm/CSS/CSSList/CSSList.php
@@ -62,7 +62,7 @@ abstract class CSSList implements Renderable, Commentable {
 				$oListItem->setComments($comments);
 				$oList->append($oListItem);
 			}
-			$oParserState->consumeWhiteSpace();
+			$oParserState->consumeWhiteSpace(false);
 		}
 		if(!$bIsRoot && !$bLenientParsing) {
 			throw new SourceException("Unexpected end of document", $oParserState->currentLine());

--- a/lib/Sabberworm/CSS/Parsing/ParserState.php
+++ b/lib/Sabberworm/CSS/Parsing/ParserState.php
@@ -112,11 +112,14 @@ class ParserState {
 		return null;
 	}
 
-	public function consumeWhiteSpace() {
+	public function consumeWhiteSpace($consumeComments = true) {
 		$comments = array();
 		do {
 			while (preg_match('/\\s/isSu', $this->peek()) === 1) {
 				$this->consume(1);
+			}
+			if (!$consumeComments) {
+				return;
 			}
 			if($this->oParserSettings->bLenientParsing) {
 				try {

--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -56,7 +56,7 @@ class Rule implements Renderable, Commentable {
 		while ($oParserState->comes(';')) {
 			$oParserState->consume(';');
 		}
-		$oParserState->consumeWhiteSpace();
+		$oParserState->consumeWhiteSpace(false);
 
 		return $oRule;
 	}

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -733,6 +733,16 @@ body {background-url: url("http://somesite.com/images/someimage.gif");}';
 		$this->assertEquals("Find Me!", $comments[0]->getComment());
 	}
 
+	function testInnerCommentExtracting() {
+		$parser = new Parser('div {left:10px;/*Find Me!*/text-align:left;}');
+		$doc = $parser->parse();
+		$contents = $doc->getContents();
+		$divRules = $contents[0]->getRules();
+		$comments = $divRules[1]->getComments();
+		$this->assertCount(1, $comments);
+		$this->assertEquals("Find Me!", $comments[0]->getComment());
+	}
+
 	function testTopLevelCommentExtracting() {
 		$parser = new Parser('/*Find Me!*/div {left:10px; text-align:left;}');
 		$doc = $parser->parse();


### PR DESCRIPTION
Comments in the middle of a rule (i.e. between two properties) don't make it to the parsed AST.

This used to work but stopped working in c468e71