### PR TITLE
Removed vm unit from ABSOLUTE_SIZE_UNITS

### DIFF
--- a/lib/Sabberworm/CSS/Value/Size.php
+++ b/lib/Sabberworm/CSS/Value/Size.php
@@ -6,7 +6,7 @@ use Sabberworm\CSS\Parsing\ParserState;
 
 class Size extends PrimitiveValue {
 
-	const ABSOLUTE_SIZE_UNITS = 'px/cm/mm/mozmm/in/pt/pc/vh/vw/vm/vmin/vmax/rem'; //vh/vw/vm(ax)/vmin/rem are absolute insofar as they don’t scale to the immediate parent (only the viewport)
+	const ABSOLUTE_SIZE_UNITS = 'px/cm/mm/mozmm/in/pt/pc/vh/vw/vmin/vmax/rem'; //vh/vw/vm(ax)/vmin/rem are absolute insofar as they don’t scale to the immediate parent (only the viewport)
 	const RELATIVE_SIZE_UNITS = '%/em/ex/ch/fr';
 	const NON_SIZE_UNITS = 'deg/grad/rad/s/ms/turns/Hz/kHz';
 


### PR DESCRIPTION
Currently e.g. `1vmax` is rendered as `1vm ax`. Removing `vm` from ABSOLUTE_SIZE_UNITS fixes that issue. Afaik there is no such unit as `vm`.