### PR TITLE
Preserve casing for CSS var names

### DIFF
--- a/lib/Sabberworm/CSS/Rule/Rule.php
+++ b/lib/Sabberworm/CSS/Rule/Rule.php
@@ -32,7 +32,7 @@ class Rule implements Renderable, Commentable {
 
 	public static function parse(ParserState $oParserState) {
 		$aComments = $oParserState->consumeWhiteSpace();
-		$oRule = new Rule($oParserState->parseIdentifier(), $oParserState->currentLine());
+		$oRule = new Rule($oParserState->parseIdentifier(!$oParserState->comes("--")), $oParserState->currentLine());
 		$oRule->setComments($aComments);
 		$oRule->addComments($oParserState->consumeWhiteSpace());
 		$oParserState->consume(':');


### PR DESCRIPTION
The casing of custom property names must be preserved as described in this document https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties