### PR TITLE
Escape identifier characters which are outside of the allowed range

### DIFF
--- a/lib/Sabberworm/CSS/Parsing/ParserState.php
+++ b/lib/Sabberworm/CSS/Parsing/ParserState.php
@@ -55,7 +55,11 @@ class ParserState {
 		}
 		$sCharacter = null;
 		while (($sCharacter = $this->parseCharacter(true)) !== null) {
-			$sResult .= $sCharacter;
+			if (preg_match('/[a-zA-Z0-9\x{00A0}-\x{FFFF}_-]/Sux', $sCharacter)) {
+				$sResult .= $sCharacter;
+			} else {
+				$sResult .= '\\' . $sCharacter;
+			}
 		}
 		if ($bIgnoreCase) {
 			$sResult = $this->strtolower($sResult);

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -466,6 +466,12 @@ body {background-color: red;}';
 		$this->assertSame($sExpected, $oDoc->render());
 	}
 
+	function testIdentifierEscapesInFile() {
+		$oDoc = $this->parsedStructureForFile('identifier-escapes', Settings::create()->withMultibyteSupport(true));
+		$sExpected = 'div {font: 14px Font Awesome\ 5 Pro;font: 14px Font Awesome\} 5 Pro;font: 14px Font Awesome\; 5 Pro;f\;ont: 14px Font Awesome\; 5 Pro;}';
+		$this->assertSame($sExpected, $oDoc->render());
+	}
+
 	function testSelectorIgnoresInFile() {
 		$oDoc = $this->parsedStructureForFile('selector-ignores', Settings::create()->withMultibyteSupport(true));
 		$sExpected = '.some[selectors-may=\'contain-a-{\'] {}

--- a/tests/files/identifier-escapes.css
+++ b/tests/files/identifier-escapes.css
@@ -1,0 +1,6 @@
+div {
+  font: 14px Font Awesome\ 5 Pro;
+  font: 14px Font Awesome\} 5 Pro;
+  font: 14px Font Awesome\; 5 Pro;
+  f\;ont: 14px Font Awesome\; 5 Pro;
+}


### PR DESCRIPTION
When parsing identifiers take into account the character rules described here: https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier and escape any character outside of the list of allowed characters.

Amongst other things this resolves issues with unquoted font family definitions like:
```CSS
font: 14px Font Awesome\ 5 Pro;
```