### PR TITLE
Add an `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file, and with same defaults
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+max_line_length = 120
+
+[*.md]
+max_line_length = 80
+# GitHub-flavored markdown uses two spaces and the end of a line to indicate a linebreak.
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.editorconfig export-ignore
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
This helps contributors get the basic formatting options in their IDEs
automatically set right. (The setting for PHP files complies to the
PSR-12 standard.)

This change does not autoformat any files with these settings, though.