### PR TITLE
Require PHP >= 5.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: [ '5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
+        php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
 
     steps:
       - name: Checkout
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3' ]
+        php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3' ]
         coverage: [ 'none' ]
         include:
           - php-version: 7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## x.y.z
 
-* Require PHP >= 5.6
+* Require PHP ≥ 5.6
 
 ## 8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision History
 
+## x.y
+
+## x.y.z
+
+* Require PHP >= 5.6
+
 ## 8.0
 
 ### 8.0.0 (2016-06-30)

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         {"name": "Raphael Schweikert"}
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.6.20"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36",


### PR DESCRIPTION
Now the PHP version requirement is on par with WordPress:
https://wordpress.org/support/article/requirements/

Fixes #207