### PR TITLE
Add Composer scripts for code sniffing and autofixing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore
+/.phive/
 /Doxyfile export-ignore
+/phpcs.xml export-ignore
 /phpunit.xml export-ignore
 /tests export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+/.phive/*
+/.php_cs.cache
 /composer.lock
 /vendor/
+!/.phive/phars.xml

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="phpcbf" version="^3.6.0" location="./.phive/phpcbf.phar" copy="false" installed="3.6.0"/>
+  <phar name="phpcs" version="^3.6.0" location="./.phive/phpcs.phar" copy="false" installed="3.6.0"/>
+</phive>

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,18 @@
     },
     "autoload": {
         "psr-4": { "Sabberworm\\CSS\\": "lib/Sabberworm/CSS/" }
+    },
+    "scripts": {
+        "ci": [
+            "@ci:static"
+        ],
+        "ci:php:sniff": "@php ./.phive/phpcs.phar lib tests",
+        "ci:static": [
+            "@ci:php:sniff"
+        ],
+        "fix:php": [
+            "@fix:php:sniff"
+        ],
+        "fix:php:sniff": "@php ./.phive/phpcbf.phar lib tests"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="phpList Coding Standard">
+    <description>
+        This standard requires PHP_CodeSniffer >= 3.6.0.
+    </description>
+
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+
+    <!-- The complete PSR-12 ruleset -->
+    <rule ref="PSR12">
+        <!-- Exclude a rule that requires PHP >= 7.1. -->
+        <exclude name="PSR12.Properties.ConstantVisibility"/>
+    </rule>
+</ruleset>


### PR DESCRIPTION
There now are the following new Composer scripts:

- `ci`: run all CI-related Composer scripts
- `ci:static` run the static code analysis
- `ci:php:sniff` run PHP_CodeSniffer
- `fix:php` fix the autofixable PHP code warnings
- `fix:php:sniff` fix the autofixable PHP_CodeSniffer warnings

For starters, we have a sniff that checks for the PSR-12 standard.
(The CI builds do not run this check as the files are not
PSR-12 compliant yet at this point.)