### PR TITLE
Stop trying to upload the coverage if there is no auth token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Run Tests
         run: ./vendor/bin/phpunit --coverage-clover build/coverage/xml
 
-      - name: Upload coverage results to Coveralls
-        if: "${{ matrix.coverage != 'none' }}"
+      - name: Upload coverage results to Codacy
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        if: "${{ matrix.coverage != 'none' && env.CODACY_PROJECT_TOKEN != '' }}"
         run: |
           ./vendor/bin/codacycoverage clover build/coverage/xml


### PR DESCRIPTION
This fixes build failures on pull requests from forks (where
usually no authentication token for the code coverage is set).