### PR TITLE
Add static type analysis with PHPStan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,7 @@
 /.phive/
 /Doxyfile export-ignore
 /phpcs.xml export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon.dist export-ignore
 /phpunit.xml export-ignore
 /tests export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,41 @@ jobs:
         if: "${{ matrix.coverage != 'none' && env.CODACY_PROJECT_TOKEN != '' }}"
         run: |
           ./vendor/bin/codacycoverage clover build/coverage/xml
+
+  phpstan:
+    name: PHPStan
+
+    runs-on: ubuntu-20.04
+
+    needs: [ php-lint ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: "composer:v2, phive"
+          coverage: none
+
+      - name: Cache dependencies installed with composer
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/composer
+          key: php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            php${{ matrix.php-version }}-composer-
+
+      - name: Install Composer dependencies
+        run: |
+          composer update --with-dependencies --no-progress;
+          composer show;
+
+      - name: Install development tools
+        run: |
+          echo y | phive --no-progress update phpstan;
+
+      - name: Run PHPStan
+        run: "composer ci:php:stan"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.phive/*
 /.php_cs.cache
 /composer.lock
+/phpstan.neon
 /vendor/
 !/.phive/phars.xml

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -2,4 +2,5 @@
 <phive xmlns="https://phar.io/phive">
   <phar name="phpcbf" version="^3.6.0" location="./.phive/phpcbf.phar" copy="false" installed="3.6.0"/>
   <phar name="phpcs" version="^3.6.0" location="./.phive/phpcs.phar" copy="false" installed="3.6.0"/>
+  <phar name="phpstan" version="^0.12.88" installed="0.12.88" location="./.phive/phpstan.phar" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,15 @@
             "@ci:static"
         ],
         "ci:php:sniff": "@php ./.phive/phpcs.phar lib tests",
+        "ci:php:stan": "@php ./.phive/phpstan.phar",
         "ci:static": [
-            "@ci:php:sniff"
+            "@ci:php:sniff",
+            "@ci:php:stan"
         ],
         "fix:php": [
             "@fix:php:sniff"
         ],
-        "fix:php:sniff": "@php ./.phive/phpcbf.phar lib tests"
+        "fix:php:sniff": "@php ./.phive/phpcbf.phar lib tests",
+        "phpstan:baseline": "@php ./.phive/phpstan.phar --generate-baseline"
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,27 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Class Sabberworm\\\\CSS\\\\Parsing\\\\ParserState constructor invoked with 1 parameter, 2\\-3 required\\.$#"
+			count: 1
+			path: lib/Sabberworm/CSS/CSSList/CSSList.php
+
+		-
+			message: "#^Access to an undefined property Sabberworm\\\\CSS\\\\Parsing\\\\ParserState\\:\\:\\$oParserHelper\\.$#"
+			count: 1
+			path: lib/Sabberworm/CSS/Parsing/ParserState.php
+
+		-
+			message: "#^Access to an undefined property Sabberworm\\\\CSS\\\\Property\\\\Charset\\:\\:\\$aComments\\.$#"
+			count: 5
+			path: lib/Sabberworm/CSS/Property/Charset.php
+
+		-
+			message: "#^Class PHPUnit\\\\Framework\\\\TestCase referenced with incorrect case\\: PHPunit\\\\Framework\\\\TestCase\\.$#"
+			count: 1
+			path: tests/Sabberworm/CSS/OutputFormatTest.php
+
+		-
+			message: "#^Class PHPUnit\\\\Framework\\\\TestCase referenced with incorrect case\\: PHPunit\\\\Framework\\\\TestCase\\.$#"
+			count: 1
+			path: tests/Sabberworm/CSS/ParserTest.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,16 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+  parallel:
+    # Don't be overly greedy on machines with more CPU's to be a good neighbor especially on CI
+    maximumNumberOfProcesses: 5
+
+  level: 0
+
+  scanDirectories:
+    - %currentWorkingDirectory%/lib/
+    - %currentWorkingDirectory%/tests/
+  paths:
+    - %currentWorkingDirectory%/lib/
+    - %currentWorkingDirectory%/tests/


### PR DESCRIPTION
Add Composer scripts for checking the code with PHPStan (while using
a baseline) and for updating the baseline.

When we fix PHPStan-reported issues (or update the PHPStan configuration),
we can update the baseline bit by bit until all issues are fixed.