### PR TITLE
Add linting with PHP 8 to the CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4' ]
+        php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
We cannot (easily) run the unit tests with PHP 8 yet as long as we still
support PHP 5.6 because there is no version of PHPUnit that runs on
PHP from 5.6 up to 8.0.