### PR TITLE
Drop an unused and redundant `phpunit.xml`

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,1 +1,0 @@
-<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
There already is a `phpunit.xml` in the project root, and there is no
need to have another copy in `tests/`.

Fixes #229