### PR TITLE
Drop the PHPUnit bootstrap

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,6 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
-    bootstrap="tests/bootstrap.php">
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd">
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>tests</directory>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,0 @@
-<?php
-
-spl_autoload_register(function ($class) {
-    $file = __DIR__ . '/../lib/' . strtr($class, '\\', '/') . '.php';
-    if (file_exists($file)) {
-        require $file;
-        return true;
-    }
-});


### PR DESCRIPTION
The bootstrap was used for autoloading. With the Composer autoloader,
it is no longer needed.