### PR TITLE
Fix faulty `.gitattributes` entry for the PHIVE configuration file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore
-/.phive/
+/.phive/ export-ignore
 /Doxyfile export-ignore
 /phpcs.xml export-ignore
 /phpunit.xml export-ignore


### PR DESCRIPTION
A path isn't enough - we also need the `export-ignore`.