### PR TITLE
Drop incorrect parenthesis around PHPDoc type annotations

### DIFF
--- a/lib/Sabberworm/CSS/CSSList/Document.php
+++ b/lib/Sabberworm/CSS/CSSList/Document.php
@@ -63,10 +63,10 @@ class Document extends CSSBlockList
 
     /**
      * Returns all Value objects found recursively in the tree.
-     * @param (object|string) $mElement
+     * @param object|string $mElement
      *        the CSSList or RuleSet to start the search from (defaults to the whole document).
-     *        If a string is given, it is used as rule name filter (@see{RuleSet->getRules()}).
-     * @param (bool) $bSearchInFunctionArguments whether to also return Value objects used as Function arguments.
+     *        If a string is given, it is used as rule name filter (@see RuleSet->getRules()).
+     * @param bool $bSearchInFunctionArguments whether to also return Value objects used as Function arguments.
      */
     public function getAllValues($mElement = null, $bSearchInFunctionArguments = false)
     {

--- a/lib/Sabberworm/CSS/RuleSet/RuleSet.php
+++ b/lib/Sabberworm/CSS/RuleSet/RuleSet.php
@@ -161,7 +161,7 @@ abstract class RuleSet implements Renderable, Commentable
      * like { background-color: green; background-color; rgba(0, 127, 0, 0.7); } will only yield an associative array
      * containing the rgba-valued rule while @link{getRules()} would yield an indexed array containing both.
      *
-     * @param (string) $mRule
+     * @param string $mRule
      *        pattern to search for. If null, returns all rules. if the pattern ends with a dash,
      *        all rules starting with the pattern are returned as well as one matching the pattern with the dash
      *        excluded. passing a Rule behaves like calling getRules($mRule->getRule()).
@@ -184,7 +184,7 @@ abstract class RuleSet implements Renderable, Commentable
      * Note: this is different from pre-v.2.0 behaviour of PHP-CSS-Parser, where passing a Rule instance would
      * remove all rules with the same name. To get the old behvaiour, use removeRule($oRule->getRule()).
      *
-     * @param (null|string|Rule) $mRule
+     * @param null|string|Rule $mRule
      *        pattern to remove. If $mRule is null, all rules are removed. If the pattern ends in a dash,
      *        all rules starting with the pattern are removed as well as one matching the pattern with the dash
      *        excluded. Passing a Rule behaves matches by identity.


### PR DESCRIPTION
Intersection types like `string|int` must not be enclosed in
parenthesis in order to be recognized.

Also drop unnecessary curly braces for an `@see` annotation.