### PR TITLE
Fix the casing in the used PHPUnit namespaces

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15,13 +15,3 @@ parameters:
 			count: 5
 			path: lib/Sabberworm/CSS/Property/Charset.php
 
-		-
-			message: "#^Class PHPUnit\\\\Framework\\\\TestCase referenced with incorrect case\\: PHPunit\\\\Framework\\\\TestCase\\.$#"
-			count: 1
-			path: tests/Sabberworm/CSS/OutputFormatTest.php
-
-		-
-			message: "#^Class PHPUnit\\\\Framework\\\\TestCase referenced with incorrect case\\: PHPunit\\\\Framework\\\\TestCase\\.$#"
-			count: 1
-			path: tests/Sabberworm/CSS/ParserTest.php
-

--- a/tests/Sabberworm/CSS/OutputFormatTest.php
+++ b/tests/Sabberworm/CSS/OutputFormatTest.php
@@ -21,7 +21,7 @@ $TEST_CSS = <<<EOT
 
 EOT;
 
-class OutputFormatTest extends \PHPunit\Framework\TestCase
+class OutputFormatTest extends \PHPUnit\Framework\TestCase
 {
     private $oParser;
     private $oDocument;

--- a/tests/Sabberworm/CSS/ParserTest.php
+++ b/tests/Sabberworm/CSS/ParserTest.php
@@ -14,7 +14,7 @@ use Sabberworm\CSS\RuleSet\DeclarationBlock;
 use Sabberworm\CSS\Value\Size;
 use Sabberworm\CSS\Value\URL;
 
-class ParserTest extends \PHPunit\Framework\TestCase
+class ParserTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testFiles()


### PR DESCRIPTION
This fixes some PHPStan warnings.