### PR TITLE
Autoformat all PHP files with PhpStorm

### DIFF
--- a/src/CSSList/AtRuleBlockList.php
+++ b/src/CSSList/AtRuleBlockList.php
@@ -61,7 +61,7 @@ class AtRuleBlockList extends CSSBlockList implements AtRule
         if ($sArgs) {
             $sArgs = ' ' . $sArgs;
         }
-        $sResult  = $oOutputFormat->sBeforeAtRuleBlock;
+        $sResult = $oOutputFormat->sBeforeAtRuleBlock;
         $sResult .= "@{$this->sType}$sArgs{$oOutputFormat->spaceBeforeOpeningBrace()}{";
         $sResult .= parent::render($oOutputFormat);
         $sResult .= '}';

--- a/src/CSSList/CSSList.php
+++ b/src/CSSList/CSSList.php
@@ -219,7 +219,6 @@ abstract class CSSList implements Renderable, Commentable
             ?: preg_match("/^(-\\w+-)?$sMatch$/i", $sIdentifier) === 1;
     }
 
-
     /**
      * @return int
      */
@@ -251,8 +250,8 @@ abstract class CSSList implements Renderable, Commentable
     /**
      * Splice the list of contents.
      *
-     * @param int       $iOffset      Offset.
-     * @param int       $iLength      Length. Optional.
+     * @param int $iOffset Offset.
+     * @param int $iLength Length. Optional.
      * @param RuleSet[] $mReplacement Replacement. Optional.
      */
     public function splice($iOffset, $iLength = null, $mReplacement = null)
@@ -302,6 +301,7 @@ abstract class CSSList implements Renderable, Commentable
 
     /**
      * Set the contents.
+     *
      * @param array<int, RuleSet|Import|Charset|CSSList> $aContents Objects to set as content.
      */
     public function setContents(array $aContents)
@@ -314,6 +314,7 @@ abstract class CSSList implements Renderable, Commentable
 
     /**
      * Removes a declaration block from the CSS list if it matches all given selectors.
+     *
      * @param array|string $mSelector The selectors to match.
      * @param boolean $bRemoveAll Whether to stop at the first declaration block found or remove all blocks
      */
@@ -391,8 +392,8 @@ abstract class CSSList implements Renderable, Commentable
     }
 
     /**
-    * Return true if the list can not be further outdented. Only important when rendering.
-    */
+     * Return true if the list can not be further outdented. Only important when rendering.
+     */
     abstract public function isRootList();
 
     /**

--- a/src/CSSList/Document.php
+++ b/src/CSSList/Document.php
@@ -12,6 +12,7 @@ class Document extends CSSBlockList
 {
     /**
      * Document constructor.
+     *
      * @param int $iLineNo
      */
     public function __construct($iLineNo = 0)
@@ -63,10 +64,13 @@ class Document extends CSSBlockList
 
     /**
      * Returns all Value objects found recursively in the tree.
+     *
      * @param object|string $mElement
      *        the CSSList or RuleSet to start the search from (defaults to the whole document).
-     *        If a string is given, it is used as rule name filter (@see RuleSet->getRules()).
+     *        If a string is given, it is used as rule name filter.
      * @param bool $bSearchInFunctionArguments whether to also return Value objects used as Function arguments.
+     *
+     * @see RuleSet->getRules()
      */
     public function getAllValues($mElement = null, $bSearchInFunctionArguments = false)
     {
@@ -90,6 +94,7 @@ class Document extends CSSBlockList
      * @param string $sSpecificitySearch
      *        An optional filter by specificity.
      *        May contain a comparison operator and a number or just a number (defaults to "==").
+     *
      * @example getSelectorsBySpecificity('>= 100')
      */
     public function getSelectorsBySpecificity($sSpecificitySearch = null)
@@ -118,7 +123,6 @@ class Document extends CSSBlockList
             $oDeclaration->createShorthands();
         }
     }
-
 
     /**
      * Override render() to make format argument optional

--- a/src/CSSList/KeyFrame.php
+++ b/src/CSSList/KeyFrame.php
@@ -20,7 +20,7 @@ class KeyFrame extends CSSList implements AtRule
     {
         parent::__construct($iLineNo);
         $this->vendorKeyFrame = null;
-        $this->animationName  = null;
+        $this->animationName = null;
     }
 
     public function setVendorKeyFrame($vendorKeyFrame)

--- a/src/Comment/Comment.php
+++ b/src/Comment/Comment.php
@@ -7,6 +7,7 @@ use Sabberworm\CSS\Renderable;
 class Comment implements Renderable
 {
     protected $iLineNo;
+
     protected $sComment;
 
     public function __construct($sComment = '', $iLineNo = 0)

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -5,72 +5,85 @@ namespace Sabberworm\CSS;
 /**
  * Class OutputFormat
  *
- * @method OutputFormat setSemicolonAfterLastRule( bool $bSemicolonAfterLastRule ) Set whether semicolons are added after last rule.
+ * @method OutputFormat setSemicolonAfterLastRule(bool $bSemicolonAfterLastRule) Set whether semicolons are added after
+ *     last rule.
  */
 class OutputFormat
 {
     /**
-    * Value format
-    */
+     * Value format
+     */
     // " means double-quote, ' means single-quote
     public $sStringQuotingType = '"';
+
     // Output RGB colors in hash notation if possible
     public $bRGBHashNotation = true;
 
     /**
-    * Declaration format
-    */
+     * Declaration format
+     */
     // Semicolon after the last rule of a declaration block can be omitted. To do that, set this false.
     public $bSemicolonAfterLastRule = true;
 
     /**
-    * Spacing
-    * Note that these strings are not sanity-checked: the value should only consist of whitespace
-    * Any newline character will be indented according to the current level.
-    * The triples (After, Before, Between) can be set using a wildcard (e.g. `$oFormat->set('Space*Rules', "\n");`)
-    */
+     * Spacing
+     * Note that these strings are not sanity-checked: the value should only consist of whitespace
+     * Any newline character will be indented according to the current level.
+     * The triples (After, Before, Between) can be set using a wildcard (e.g. `$oFormat->set('Space*Rules', "\n");`)
+     */
     public $sSpaceAfterRuleName = ' ';
 
     public $sSpaceBeforeRules = '';
+
     public $sSpaceAfterRules = '';
+
     public $sSpaceBetweenRules = '';
 
     public $sSpaceBeforeBlocks = '';
+
     public $sSpaceAfterBlocks = '';
+
     public $sSpaceBetweenBlocks = "\n";
 
     // Content injected in and around @-rule blocks.
     public $sBeforeAtRuleBlock = '';
+
     public $sAfterAtRuleBlock = '';
 
     // This is what’s printed before and after the comma if a declaration block contains multiple selectors.
     public $sSpaceBeforeSelectorSeparator = '';
+
     public $sSpaceAfterSelectorSeparator = ' ';
+
     // This is what’s printed after the comma of value lists
     public $sSpaceBeforeListArgumentSeparator = '';
+
     public $sSpaceAfterListArgumentSeparator = '';
 
     public $sSpaceBeforeOpeningBrace = ' ';
 
     // Content injected in and around declaration blocks.
     public $sBeforeDeclarationBlock = '';
+
     public $sAfterDeclarationBlockSelectors = '';
+
     public $sAfterDeclarationBlock = '';
 
     /**
-    * Indentation
-    */
+     * Indentation
+     */
     // Indentation character(s) per level. Only applicable if newlines are used in any of the spacing settings.
     public $sIndentation = "\t";
 
     /**
-    * Output exceptions.
-    */
+     * Output exceptions.
+     */
     public $bIgnoreExceptions = false;
 
-
     private $oFormatter = null;
+
     private $oNextLevelFormat = null;
+
     private $iIndentationLevel = 0;
 
     public function __construct()
@@ -93,7 +106,12 @@ class OutputFormat
     {
         $aVarPrefixes = ['a', 's', 'm', 'b', 'f', 'o', 'c', 'i'];
         if (is_string($aNames) && strpos($aNames, '*') !== false) {
-            $aNames = [str_replace('*', 'Before', $aNames), str_replace('*', 'Between', $aNames), str_replace('*', 'After', $aNames)];
+            $aNames =
+                [
+                    str_replace('*', 'Before', $aNames),
+                    str_replace('*', 'Between', $aNames),
+                    str_replace('*', 'After', $aNames),
+                ];
         } elseif (!is_array($aNames)) {
             $aNames = [$aNames];
         }

--- a/src/Parsing/OutputException.php
+++ b/src/Parsing/OutputException.php
@@ -3,8 +3,8 @@
 namespace Sabberworm\CSS\Parsing;
 
 /**
-* Thrown if the CSS parsers attempts to print something invalid
-*/
+ * Thrown if the CSS parsers attempts to print something invalid
+ */
 class OutputException extends SourceException
 {
     public function __construct($sMessage, $iLineNo = 0)

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -14,9 +14,13 @@ class ParserState
     private $sText;
 
     private $aText;
+
     private $iCurrentPosition;
+
     private $sCharset;
+
     private $iLength;
+
     private $iLineNo;
 
     public function __construct($sText, Settings $oParserSettings, $iLineNo = 1)
@@ -117,12 +121,12 @@ class ParserState
             $peek = ord($this->peek());
             // Ranges: a-z A-Z 0-9 - _
             if (
-                ($peek >= 97 && $peek <= 122) ||
-                ($peek >= 65 && $peek <= 90) ||
-                ($peek >= 48 && $peek <= 57) ||
-                ($peek === 45) ||
-                ($peek === 95) ||
-                ($peek > 0xa1)
+                ($peek >= 97 && $peek <= 122)
+                || ($peek >= 65 && $peek <= 90)
+                || ($peek >= 48 && $peek <= 57)
+                || ($peek === 45)
+                || ($peek === 95)
+                || ($peek > 0xa1)
             ) {
                 return $this->consume(1);
             }

--- a/src/Parsing/SourceException.php
+++ b/src/Parsing/SourceException.php
@@ -5,6 +5,7 @@ namespace Sabberworm\CSS\Parsing;
 class SourceException extends \Exception
 {
     private $iLineNo;
+
     public function __construct($sMessage, $iLineNo = 0)
     {
         $this->iLineNo = $iLineNo;

--- a/src/Parsing/UnexpectedEOFException.php
+++ b/src/Parsing/UnexpectedEOFException.php
@@ -3,9 +3,9 @@
 namespace Sabberworm\CSS\Parsing;
 
 /**
-* Thrown if the CSS parsers encounters end of file it did not expect
-* Extends UnexpectedTokenException in order to preserve backwards compatibility
-*/
+ * Thrown if the CSS parsers encounters end of file it did not expect
+ * Extends UnexpectedTokenException in order to preserve backwards compatibility
+ */
 class UnexpectedEOFException extends UnexpectedTokenException
 {
 }

--- a/src/Parsing/UnexpectedTokenException.php
+++ b/src/Parsing/UnexpectedTokenException.php
@@ -3,12 +3,14 @@
 namespace Sabberworm\CSS\Parsing;
 
 /**
-* Thrown if the CSS parsers encounters a token it did not expect
-*/
+ * Thrown if the CSS parsers encounters a token it did not expect
+ */
 class UnexpectedTokenException extends SourceException
 {
     private $sExpected;
+
     private $sFound;
+
     // Possible values: literal, identifier, count, expression, search
     private $sMatchType;
 

--- a/src/Property/CSSNamespace.php
+++ b/src/Property/CSSNamespace.php
@@ -3,13 +3,16 @@
 namespace Sabberworm\CSS\Property;
 
 /**
-* CSSNamespace represents an @namespace rule.
-*/
+ * CSSNamespace represents an @namespace rule.
+ */
 class CSSNamespace implements AtRule
 {
     private $mUrl;
+
     private $sPrefix;
+
     private $iLineNo;
+
     protected $aComments;
 
     public function __construct($mUrl, $sPrefix = null, $iLineNo = 0)
@@ -40,7 +43,8 @@ class CSSNamespace implements AtRule
      */
     public function render(\Sabberworm\CSS\OutputFormat $oOutputFormat)
     {
-        return '@namespace ' . ($this->sPrefix === null ? '' : $this->sPrefix . ' ') . $this->mUrl->render($oOutputFormat) . ';';
+        return '@namespace ' . ($this->sPrefix === null ? '' : $this->sPrefix . ' ')
+            . $this->mUrl->render($oOutputFormat) . ';';
     }
 
     public function getUrl()

--- a/src/Property/Import.php
+++ b/src/Property/Import.php
@@ -5,8 +5,8 @@ namespace Sabberworm\CSS\Property;
 use Sabberworm\CSS\Value\URL;
 
 /**
-* Class representing an @import rule.
-*/
+ * Class representing an @import rule.
+ */
 class Import implements AtRule
 {
     /**
@@ -52,12 +52,12 @@ class Import implements AtRule
 
     public function setLocation($oLocation)
     {
-            $this->oLocation = $oLocation;
+        $this->oLocation = $oLocation;
     }
 
     public function getLocation()
     {
-            return $this->oLocation;
+        return $this->oLocation;
     }
 
     public function __toString()

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -3,7 +3,8 @@
 namespace Sabberworm\CSS\Property;
 
 /**
- * Class representing a single CSS selector. Selectors have to be split by the comma prior to being passed into this class.
+ * Class representing a single CSS selector. Selectors have to be split by the comma prior to being passed into this
+ * class.
  */
 class Selector
 {
@@ -47,6 +48,7 @@ class Selector
 	/ux';
 
     private $sSelector;
+
     private $iSpecificity;
 
     public static function isValid($sSelector)

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -16,11 +16,17 @@ class Rule implements Renderable, Commentable
 {
 
     private $sRule;
+
     private $mValue;
+
     private $bIsImportant;
+
     private $aIeHack;
+
     protected $iLineNo;
+
     protected $iColNo;
+
     protected $aComments;
 
     public function __construct($sRule, $iLineNo = 0, $iColNo = 0)
@@ -121,7 +127,7 @@ class Rule implements Renderable, Commentable
     }
 
     /**
-     *  @deprecated Old-Style 2-dimensional array given. Retained for (some) backwards-compatibility.
+     * @deprecated Old-Style 2-dimensional array given. Retained for (some) backwards-compatibility.
      *              Use setValue() instead and wrap the value inside a RuleValueList if necessary.
      */
     public function setValues($aSpaceSeparatedValues)
@@ -158,7 +164,7 @@ class Rule implements Renderable, Commentable
     }
 
     /**
-     *  @deprecated Old-Style 2-dimensional array returned. Retained for (some) backwards-compatibility.
+     * @deprecated Old-Style 2-dimensional array returned. Retained for (some) backwards-compatibility.
      *              Use getValue() instead and check for the existance of a (nested set of) ValueList object(s).
      */
     public function getValues()

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -69,7 +69,6 @@ class DeclarationBlock extends RuleSet
         return $oResult;
     }
 
-
     public function setSelectors($mSelector, $oList = null)
     {
         if (is_array($mSelector)) {
@@ -177,10 +176,16 @@ class DeclarationBlock extends RuleSet
     public function expandBorderShorthand()
     {
         $aBorderRules = [
-            'border', 'border-left', 'border-right', 'border-top', 'border-bottom'
+            'border',
+            'border-left',
+            'border-right',
+            'border-top',
+            'border-bottom',
         ];
         $aBorderSizes = [
-            'thin', 'medium', 'thick'
+            'thin',
+            'medium',
+            'thick',
         ];
         $aRules = $this->getRulesAssoc();
         foreach ($aBorderRules as $sBorderRule) {
@@ -233,7 +238,7 @@ class DeclarationBlock extends RuleSet
             'padding' => 'padding-%s',
             'border-color' => 'border-%s-color',
             'border-style' => 'border-%s-style',
-            'border-width' => 'border-%s-width'
+            'border-width' => 'border-%s-width',
         ];
         $aRules = $this->getRulesAssoc();
         foreach ($aExpansions as $sProperty => $sExpanded) {
@@ -297,7 +302,7 @@ class DeclarationBlock extends RuleSet
             'font-variant' => 'normal',
             'font-weight' => 'normal',
             'font-size' => 'normal',
-            'line-height' => 'normal'
+            'line-height' => 'normal',
         ];
         $mRuleValue = $oRule->getValue();
         $aValues = [];
@@ -321,8 +326,8 @@ class DeclarationBlock extends RuleSet
             } elseif ($mValue == 'small-caps') {
                 $aFontProperties['font-variant'] = $mValue;
             } elseif (
-                    in_array($mValue, ['bold', 'bolder', 'lighter'])
-                    || ($mValue instanceof Size
+                in_array($mValue, ['bold', 'bolder', 'lighter'])
+                || ($mValue instanceof Size
                     && in_array($mValue->getSize(), range(100, 900, 100)))
             ) {
                 $aFontProperties['font-weight'] = $mValue;
@@ -360,11 +365,14 @@ class DeclarationBlock extends RuleSet
         }
         $oRule = $aRules['background'];
         $aBgProperties = [
-            'background-color' => ['transparent'], 'background-image' => ['none'],
-            'background-repeat' => ['repeat'], 'background-attachment' => ['scroll'],
+            'background-color' => ['transparent'],
+            'background-image' => ['none'],
+            'background-repeat' => ['repeat'],
+            'background-attachment' => ['scroll'],
             'background-position' => [
-                new Size(0, '%', null, false, $this->iLineNo), new Size(0, '%', null, false, $this->iLineNo)
-            ]
+                new Size(0, '%', null, false, $this->iLineNo),
+                new Size(0, '%', null, false, $this->iLineNo),
+            ],
         ];
         $mRuleValue = $oRule->getValue();
         $aValues = [];
@@ -398,7 +406,7 @@ class DeclarationBlock extends RuleSet
                 $aBgProperties['background-repeat'] = $mValue;
             } elseif (
                 in_array($mValue, ['left', 'center', 'right', 'top', 'bottom'])
-                    || $mValue instanceof Size
+                || $mValue instanceof Size
             ) {
                 if ($iNumBgPos == 0) {
                     $aBgProperties['background-position'][0] = $mValue;
@@ -423,16 +431,34 @@ class DeclarationBlock extends RuleSet
         $aListProperties = [
             'list-style-type' => 'disc',
             'list-style-position' => 'outside',
-            'list-style-image' => 'none'
+            'list-style-image' => 'none',
         ];
         $aListStyleTypes = [
-            'none', 'disc', 'circle', 'square', 'decimal-leading-zero', 'decimal',
-            'lower-roman', 'upper-roman', 'lower-greek', 'lower-alpha', 'lower-latin',
-            'upper-alpha', 'upper-latin', 'hebrew', 'armenian', 'georgian', 'cjk-ideographic',
-            'hiragana', 'hira-gana-iroha', 'katakana-iroha', 'katakana'
+            'none',
+            'disc',
+            'circle',
+            'square',
+            'decimal-leading-zero',
+            'decimal',
+            'lower-roman',
+            'upper-roman',
+            'lower-greek',
+            'lower-alpha',
+            'lower-latin',
+            'upper-alpha',
+            'upper-latin',
+            'hebrew',
+            'armenian',
+            'georgian',
+            'cjk-ideographic',
+            'hiragana',
+            'hira-gana-iroha',
+            'katakana-iroha',
+            'katakana',
         ];
         $aListStylePositions = [
-            'inside', 'outside'
+            'inside',
+            'outside',
         ];
         $aRules = $this->getRulesAssoc();
         if (!isset($aRules['list-style'])) {
@@ -512,8 +538,11 @@ class DeclarationBlock extends RuleSet
     public function createBackgroundShorthand()
     {
         $aProperties = [
-            'background-color', 'background-image', 'background-repeat',
-            'background-position', 'background-attachment'
+            'background-color',
+            'background-image',
+            'background-repeat',
+            'background-position',
+            'background-attachment',
         ];
         $this->createShorthandProperties($aProperties, 'background');
     }
@@ -521,7 +550,9 @@ class DeclarationBlock extends RuleSet
     public function createListStyleShorthand()
     {
         $aProperties = [
-            'list-style-type', 'list-style-position', 'list-style-image'
+            'list-style-type',
+            'list-style-position',
+            'list-style-image',
         ];
         $this->createShorthandProperties($aProperties, 'list-style');
     }
@@ -533,7 +564,9 @@ class DeclarationBlock extends RuleSet
     public function createBorderShorthand()
     {
         $aProperties = [
-            'border-width', 'border-style', 'border-color'
+            'border-width',
+            'border-style',
+            'border-color',
         ];
         $this->createShorthandProperties($aProperties, 'border');
     }
@@ -552,7 +585,7 @@ class DeclarationBlock extends RuleSet
             'padding' => 'padding-%s',
             'border-color' => 'border-%s-color',
             'border-style' => 'border-%s-style',
-            'border-width' => 'border-%s-width'
+            'border-width' => 'border-%s-width',
         ];
         $aRules = $this->getRulesAssoc();
         foreach ($aExpansions as $sProperty => $sExpanded) {
@@ -579,9 +612,9 @@ class DeclarationBlock extends RuleSet
                     $aValues[$sPosition] = $aRuleValues;
                 }
                 $oNewRule = new Rule($sProperty, $oRule->getLineNo(), $oRule->getColNo());
-                if ((string) $aValues['left'][0] == (string) $aValues['right'][0]) {
-                    if ((string) $aValues['top'][0] == (string) $aValues['bottom'][0]) {
-                        if ((string) $aValues['top'][0] == (string) $aValues['left'][0]) {
+                if ((string)$aValues['left'][0] == (string)$aValues['right'][0]) {
+                    if ((string)$aValues['top'][0] == (string)$aValues['bottom'][0]) {
+                        if ((string)$aValues['top'][0] == (string)$aValues['left'][0]) {
                             // All 4 sides are equal
                             $oNewRule->addValue($aValues['top']);
                         } else {
@@ -618,7 +651,12 @@ class DeclarationBlock extends RuleSet
     public function createFontShorthand()
     {
         $aFontProperties = [
-            'font-style', 'font-variant', 'font-weight', 'font-size', 'line-height', 'font-family'
+            'font-style',
+            'font-variant',
+            'font-weight',
+            'font-size',
+            'line-height',
+            'font-family',
         ];
         $aRules = $this->getRulesAssoc();
         if (!isset($aRules['font-size']) || !isset($aRules['font-family'])) {

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -16,7 +16,9 @@ abstract class RuleSet implements Renderable, Commentable
 {
 
     private $aRules;
+
     protected $iLineNo;
+
     protected $aComments;
 
     public function __construct($iLineNo = 0)
@@ -102,15 +104,16 @@ abstract class RuleSet implements Renderable, Commentable
     /**
      * Returns all rules matching the given rule name
      *
+     * @example $oRuleSet->getRules('font') // returns array(0 => $oRule, …) or array().
+     *
+     * @example $oRuleSet->getRules('font-')
+     *          //returns an array of all rules either beginning with font- or matching font.
+     *
      * @param null|string|Rule $mRule
      *        pattern to search for. If null, returns all rules.
      *        if the pattern ends with a dash, all rules starting with the pattern are returned
      *        as well as one matching the pattern with the dash excluded.
      *        passing a Rule behaves like calling getRules($mRule->getRule()).
-     *
-     * @example $oRuleSet->getRules('font-')
-     *          //returns an array of all rules either beginning with font- or matching font.
-     * @example $oRuleSet->getRules('font') //returns array(0 => $oRule, …) or array().
      *
      * @return array<int, Rule> Rules.
      */
@@ -143,6 +146,7 @@ abstract class RuleSet implements Renderable, Commentable
 
     /**
      * Override all the rules of this set.
+     *
      * @param Rule[] $aRules The rules to override with.
      */
     public function setRules(array $aRules)
@@ -159,12 +163,13 @@ abstract class RuleSet implements Renderable, Commentable
      *
      * Note: This method loses some information: Calling this (with an argument of 'background-') on a declaration block
      * like { background-color: green; background-color; rgba(0, 127, 0, 0.7); } will only yield an associative array
-     * containing the rgba-valued rule while @link{getRules()} would yield an indexed array containing both.
+     * containing the rgba-valued rule while `getRules()` would yield an indexed array containing both.
      *
      * @param string $mRule
      *        pattern to search for. If null, returns all rules. if the pattern ends with a dash,
      *        all rules starting with the pattern are returned as well as one matching the pattern with the dash
      *        excluded. passing a Rule behaves like calling getRules($mRule->getRule()).
+     *
      * @return Rule[] Rules.
      */
     public function getRulesAssoc($mRule = null)
@@ -177,12 +182,13 @@ abstract class RuleSet implements Renderable, Commentable
     }
 
     /**
-     * Remove a rule from this RuleSet. This accepts all the possible values that @link{getRules()} accepts.
+     * Remove a rule from this RuleSet. This accepts all the possible values that `getRules()` accepts.
+     *
      * If given a Rule, it will only remove this particular rule (by identity).
      * If given a name, it will remove all rules by that name.
      *
      * Note: this is different from pre-v.2.0 behaviour of PHP-CSS-Parser, where passing a Rule instance would
-     * remove all rules with the same name. To get the old behvaiour, use removeRule($oRule->getRule()).
+     * remove all rules with the same name. To get the old behaviour, use removeRule($oRule->getRule()).
      *
      * @param null|string|Rule $mRule
      *        pattern to remove. If $mRule is null, all rules are removed. If the pattern ends in a dash,

--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -7,7 +7,7 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 
 class CalcFunction extends CSSFunction
 {
-    const T_OPERAND  = 1;
+    const T_OPERAND = 1;
     const T_OPERATOR = 2;
 
     public static function parse(ParserState $oParserState)
@@ -38,7 +38,11 @@ class CalcFunction extends CSSFunction
             } else {
                 if (in_array($oParserState->peek(), $aOperators)) {
                     if (($oParserState->comes('-') || $oParserState->comes('+'))) {
-                        if ($oParserState->peek(1, -1) != ' ' || !($oParserState->comes('- ') || $oParserState->comes('+ '))) {
+                        if (
+                            $oParserState->peek(1, -1) != ' '
+                            || !($oParserState->comes('- ')
+                                || $oParserState->comes('+ '))
+                        ) {
                             throw new UnexpectedTokenException(
                                 " {$oParserState->peek()} ",
                                 $oParserState->peek(1, -1) . $oParserState->peek(2),

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -35,13 +35,13 @@ class Color extends CSSFunction
                         null,
                         true,
                         $oParserState->currentLine()
-                    )
+                    ),
                 ];
             } else {
                 $aColor = [
                     'r' => new Size(intval($sValue[0] . $sValue[1], 16), null, true, $oParserState->currentLine()),
                     'g' => new Size(intval($sValue[2] . $sValue[3], 16), null, true, $oParserState->currentLine()),
-                    'b' => new Size(intval($sValue[4] . $sValue[5], 16), null, true, $oParserState->currentLine())
+                    'b' => new Size(intval($sValue[4] . $sValue[5], 16), null, true, $oParserState->currentLine()),
                 ];
             }
         } else {

--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -15,7 +15,9 @@ class Size extends PrimitiveValue
     private static $SIZE_UNITS = null;
 
     private $fSize;
+
     private $sUnit;
+
     private $bIsColorComponent;
 
     public function __construct($fSize, $sUnit = null, $bIsColorComponent = false, $iLineNo = 0)
@@ -59,7 +61,8 @@ class Size extends PrimitiveValue
         if (self::$SIZE_UNITS === null) {
             self::$SIZE_UNITS = [];
             foreach (
-                explode('/', Size::ABSOLUTE_SIZE_UNITS . '/' . Size::RELATIVE_SIZE_UNITS . '/' . Size::NON_SIZE_UNITS) as $val
+                explode('/', Size::ABSOLUTE_SIZE_UNITS . '/' . Size::RELATIVE_SIZE_UNITS . '/' . Size::NON_SIZE_UNITS)
+                as $val
             ) {
                 $iSize = strlen($val);
                 if (!isset(self::$SIZE_UNITS[$iSize])) {
@@ -101,6 +104,7 @@ class Size extends PrimitiveValue
 
     /**
      * Returns whether the number stored in this Size really represents a size (as in a length of something on screen).
+     *
      * @return false if the unit an angle, a duration, a frequency or the number is a component in a Color object.
      */
     public function isSize()

--- a/src/Value/URL.php
+++ b/src/Value/URL.php
@@ -32,7 +32,6 @@ class URL extends PrimitiveValue
         return $oResult;
     }
 
-
     public function setURL(CSSString $oURL)
     {
         $this->oURL = $oURL;

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -22,7 +22,8 @@ abstract class Value implements Renderable
         //Build a list of delimiters and parsed values
         while (
             !($oParserState->comes('}') || $oParserState->comes(';') || $oParserState->comes('!')
-            || $oParserState->comes(')') || $oParserState->comes('\\'))
+            || $oParserState->comes(')')
+            || $oParserState->comes('\\'))
         ) {
             if (count($aStack) > 0) {
                 $bFoundDelimiter = false;
@@ -92,8 +93,10 @@ abstract class Value implements Renderable
         $oValue = null;
         $oParserState->consumeWhiteSpace();
         if (
-            is_numeric($oParserState->peek()) || ($oParserState->comes('-.')
-                && is_numeric($oParserState->peek(1, 2))) || (($oParserState->comes('-') || $oParserState->comes('.')) && is_numeric($oParserState->peek(1, 1)))
+            is_numeric($oParserState->peek())
+            || ($oParserState->comes('-.')
+                && is_numeric($oParserState->peek(1, 2)))
+            || (($oParserState->comes('-') || $oParserState->comes('.')) && is_numeric($oParserState->peek(1, 1)))
         ) {
             $oValue = Size::parse($oParserState);
         } elseif ($oParserState->comes('#') || $oParserState->comes('rgb', true) || $oParserState->comes('hsl', true)) {

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -6,6 +6,7 @@ abstract class ValueList extends Value
 {
 
     protected $aComponents;
+
     protected $sSeparator;
 
     public function __construct($aComponents = [], $sSeparator = ',', $iLineNo = 0)
@@ -56,7 +57,8 @@ abstract class ValueList extends Value
     public function render(\Sabberworm\CSS\OutputFormat $oOutputFormat)
     {
         return $oOutputFormat->implode(
-            $oOutputFormat->spaceBeforeListArgumentSeparator($this->sSeparator) . $this->sSeparator . $oOutputFormat->spaceAfterListArgumentSeparator($this->sSeparator),
+            $oOutputFormat->spaceBeforeListArgumentSeparator($this->sSeparator) . $this->sSeparator
+            . $oOutputFormat->spaceAfterListArgumentSeparator($this->sSeparator),
             $this->aComponents
         );
     }

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -25,6 +25,7 @@ class OutputFormatTest extends \PHPUnit\Framework\TestCase
 EOT;
 
     private $oParser;
+
     private $oDocument;
 
     protected function setUp()
@@ -69,7 +70,12 @@ EOT;
         $this->assertSame(
             '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",	Verdana,	sans-serif;background: white;}
 @media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}',
-            $this->oDocument->render(OutputFormat::create()->setSpaceAfterListArgumentSeparator(['default' => ' ', ',' => "\t", '/' => '', ' ' => '']))
+            $this->oDocument->render(OutputFormat::create()->setSpaceAfterListArgumentSeparator([
+                'default' => ' ',
+                ',' => "\t",
+                '/' => '',
+                ' ' => '',
+            ]))
         );
     }
 
@@ -85,26 +91,38 @@ EOT;
 
     public function testStringQuotingType()
     {
-        $this->assertSame('.main, .test {font: italic normal bold 16px/1.2 \'Helvetica\',Verdana,sans-serif;background: white;}
-@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}', $this->oDocument->render(OutputFormat::create()->setStringQuotingType("'")));
+        $this->assertSame(
+            '.main, .test {font: italic normal bold 16px/1.2 \'Helvetica\',Verdana,sans-serif;background: white;}
+@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff;}}',
+            $this->oDocument->render(OutputFormat::create()->setStringQuotingType("'"))
+        );
     }
 
     public function testRGBHashNotation()
     {
-        $this->assertSame('.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
-@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: rgb(255,255,255);}}', $this->oDocument->render(OutputFormat::create()->setRGBHashNotation(false)));
+        $this->assertSame(
+            '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white;}
+@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: rgb(255,255,255);}}',
+            $this->oDocument->render(OutputFormat::create()->setRGBHashNotation(false))
+        );
     }
 
     public function testSemicolonAfterLastRule()
     {
-        $this->assertSame('.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white}
-@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff}}', $this->oDocument->render(OutputFormat::create()->setSemicolonAfterLastRule(false)));
+        $this->assertSame(
+            '.main, .test {font: italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background: white}
+@media screen {.main {background-size: 100% 100%;font-size: 1.3em;background-color: #fff}}',
+            $this->oDocument->render(OutputFormat::create()->setSemicolonAfterLastRule(false))
+        );
     }
 
     public function testSpaceAfterRuleName()
     {
-        $this->assertSame('.main, .test {font:	italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background:	white;}
-@media screen {.main {background-size:	100% 100%;font-size:	1.3em;background-color:	#fff;}}', $this->oDocument->render(OutputFormat::create()->setSpaceAfterRuleName("\t")));
+        $this->assertSame(
+            '.main, .test {font:	italic normal bold 16px/1.2 "Helvetica",Verdana,sans-serif;background:	white;}
+@media screen {.main {background-size:	100% 100%;font-size:	1.3em;background-color:	#fff;}}',
+            $this->oDocument->render(OutputFormat::create()->setSpaceAfterRuleName("\t"))
+        );
     }
 
     public function testSpaceRules()
@@ -169,7 +187,10 @@ font-size: 1.3em;
 background-color: #fff;
 }
 }
-', $this->oDocument->render(OutputFormat::create()->set('Space*Rules', "\n")->set('Space*Blocks', "\n")->setIndentation('')));
+', $this->oDocument->render(OutputFormat::create()
+            ->set('Space*Rules', "\n")
+            ->set('Space*Blocks', "\n")
+            ->setIndentation('')));
     }
 
     public function testSpaceBeforeBraces()
@@ -182,8 +203,8 @@ background-color: #fff;
     }
 
     /**
-    * @expectedException Sabberworm\CSS\Parsing\OutputException
-    */
+     * @expectedException Sabberworm\CSS\Parsing\OutputException
+     */
     public function testIgnoreExceptionsOff()
     {
         $aBlocks = $this->oDocument->getAllDeclarationBlocks();

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -62,30 +62,59 @@ class ParserTest extends \PHPUnit\Framework\TestCase
                 $this->assertSame('red', $oColor);
                 $aColorRule = $oRuleSet->getRules('background-');
                 $oColor = $aColorRule[0]->getValue();
-                $this->assertEquals(['r' => new Size(35.0, null, true, $oColor->getLineNo()), 'g' => new Size(35.0, null, true, $oColor->getLineNo()), 'b' => new Size(35.0, null, true, $oColor->getLineNo())], $oColor->getColor());
+                $this->assertEquals([
+                    'r' => new Size(35.0, null, true, $oColor->getLineNo()),
+                    'g' => new Size(35.0, null, true, $oColor->getLineNo()),
+                    'b' => new Size(35.0, null, true, $oColor->getLineNo()),
+                ], $oColor->getColor());
                 $aColorRule = $oRuleSet->getRules('border-color');
                 $oColor = $aColorRule[0]->getValue();
-                $this->assertEquals(['r' => new Size(10.0, null, true, $oColor->getLineNo()), 'g' => new Size(100.0, null, true, $oColor->getLineNo()), 'b' => new Size(230.0, null, true, $oColor->getLineNo())], $oColor->getColor());
+                $this->assertEquals([
+                    'r' => new Size(10.0, null, true, $oColor->getLineNo()),
+                    'g' => new Size(100.0, null, true, $oColor->getLineNo()),
+                    'b' => new Size(230.0, null, true, $oColor->getLineNo()),
+                ], $oColor->getColor());
                 $oColor = $aColorRule[1]->getValue();
-                $this->assertEquals(['r' => new Size(10.0, null, true, $oColor->getLineNo()), 'g' => new Size(100.0, null, true, $oColor->getLineNo()), 'b' => new Size(231.0, null, true, $oColor->getLineNo()), 'a' => new Size("0000.3", null, true, $oColor->getLineNo())], $oColor->getColor());
+                $this->assertEquals([
+                    'r' => new Size(10.0, null, true, $oColor->getLineNo()),
+                    'g' => new Size(100.0, null, true, $oColor->getLineNo()),
+                    'b' => new Size(231.0, null, true, $oColor->getLineNo()),
+                    'a' => new Size("0000.3", null, true, $oColor->getLineNo()),
+                ], $oColor->getColor());
                 $aColorRule = $oRuleSet->getRules('outline-color');
                 $oColor = $aColorRule[0]->getValue();
-                $this->assertEquals(['r' => new Size(34.0, null, true, $oColor->getLineNo()), 'g' => new Size(34.0, null, true, $oColor->getLineNo()), 'b' => new Size(34.0, null, true, $oColor->getLineNo())], $oColor->getColor());
+                $this->assertEquals([
+                    'r' => new Size(34.0, null, true, $oColor->getLineNo()),
+                    'g' => new Size(34.0, null, true, $oColor->getLineNo()),
+                    'b' => new Size(34.0, null, true, $oColor->getLineNo()),
+                ], $oColor->getColor());
             } elseif ($sSelector === '#yours') {
                 $aColorRule = $oRuleSet->getRules('background-color');
                 $oColor = $aColorRule[0]->getValue();
-                $this->assertEquals(['h' => new Size(220.0, null, true, $oColor->getLineNo()), 's' => new Size(10.0, '%', true, $oColor->getLineNo()), 'l' => new Size(220.0, '%', true, $oColor->getLineNo())], $oColor->getColor());
+                $this->assertEquals([
+                    'h' => new Size(220.0, null, true, $oColor->getLineNo()),
+                    's' => new Size(10.0, '%', true, $oColor->getLineNo()),
+                    'l' => new Size(220.0, '%', true, $oColor->getLineNo()),
+                ], $oColor->getColor());
                 $oColor = $aColorRule[1]->getValue();
-                $this->assertEquals(['h' => new Size(220.0, null, true, $oColor->getLineNo()), 's' => new Size(10.0, '%', true, $oColor->getLineNo()), 'l' => new Size(220.0, '%', true, $oColor->getLineNo()), 'a' => new Size(0000.3, null, true, $oColor->getLineNo())], $oColor->getColor());
+                $this->assertEquals([
+                    'h' => new Size(220.0, null, true, $oColor->getLineNo()),
+                    's' => new Size(10.0, '%', true, $oColor->getLineNo()),
+                    'l' => new Size(220.0, '%', true, $oColor->getLineNo()),
+                    'a' => new Size(0000.3, null, true, $oColor->getLineNo()),
+                ], $oColor->getColor());
             }
         }
         foreach ($oDoc->getAllValues('color') as $sColor) {
             $this->assertSame('red', $sColor);
         }
-        $this->assertSame('#mine {color: red;border-color: #0a64e6;border-color: rgba(10,100,231,.3);outline-color: #222;background-color: #232323;}
+        $this->assertSame(
+            '#mine {color: red;border-color: #0a64e6;border-color: rgba(10,100,231,.3);outline-color: #222;background-color: #232323;}
 #yours {background-color: hsl(220,10%,220%);background-color: hsla(220,10%,220%,.3);}
 #variables {background-color: rgb(var(--some-rgb));background-color: rgb(var(--r),var(--g),var(--b));background-color: rgb(255,var(--g),var(--b));background-color: rgb(255,255,var(--b));background-color: rgb(255,var(--rg));background-color: hsl(var(--some-hsl));}
-#variables-alpha {background-color: rgba(var(--some-rgb),.1);background-color: rgba(var(--some-rg),255,.1);background-color: hsla(var(--some-hsl),.1);}', $oDoc->render());
+#variables-alpha {background-color: rgba(var(--some-rgb),.1);background-color: rgba(var(--some-rg),255,.1);background-color: hsla(var(--some-hsl),.1);}',
+            $oDoc->render()
+        );
     }
 
     public function testUnicodeParsing()
@@ -171,11 +200,23 @@ class ParserTest extends \PHPUnit\Framework\TestCase
             }
         }
         $this->assertEquals([new Selector('#test .help', true)], $oDoc->getSelectorsBySpecificity('> 100'));
-        $this->assertEquals([new Selector('#test .help', true), new Selector('#file', true)], $oDoc->getSelectorsBySpecificity('>= 100'));
+        $this->assertEquals(
+            [new Selector('#test .help', true), new Selector('#file', true)],
+            $oDoc->getSelectorsBySpecificity('>= 100')
+        );
         $this->assertEquals([new Selector('#file', true)], $oDoc->getSelectorsBySpecificity('=== 100'));
         $this->assertEquals([new Selector('#file', true)], $oDoc->getSelectorsBySpecificity('== 100'));
-        $this->assertEquals([new Selector('#file', true), new Selector('.help:hover', true), new Selector('li.green', true), new Selector('ol li::before', true)], $oDoc->getSelectorsBySpecificity('<= 100'));
-        $this->assertEquals([new Selector('.help:hover', true), new Selector('li.green', true), new Selector('ol li::before', true)], $oDoc->getSelectorsBySpecificity('< 100'));
+        $this->assertEquals([
+            new Selector('#file', true),
+            new Selector('.help:hover', true),
+            new Selector('li.green', true),
+            new Selector('ol li::before', true),
+        ], $oDoc->getSelectorsBySpecificity('<= 100'));
+        $this->assertEquals([
+            new Selector('.help:hover', true),
+            new Selector('li.green', true),
+            new Selector('ol li::before', true),
+        ], $oDoc->getSelectorsBySpecificity('< 100'));
         $this->assertEquals([new Selector('li.green', true)], $oDoc->getSelectorsBySpecificity('11'));
         $this->assertEquals([new Selector('ol li::before', true)], $oDoc->getSelectorsBySpecificity(3));
     }
@@ -323,20 +364,24 @@ body {color: green;}', $oDoc->render());
     public function testExpandShorthands()
     {
         $oDoc = $this->parsedStructureForFile('expand-shorthands');
-        $sExpected = 'body {font: italic 500 14px/1.618 "Trebuchet MS",Georgia,serif;border: 2px solid #f0f;background: #ccc url("/images/foo.png") no-repeat left top;margin: 1em !important;padding: 2px 6px 3px;}';
+        $sExpected =
+            'body {font: italic 500 14px/1.618 "Trebuchet MS",Georgia,serif;border: 2px solid #f0f;background: #ccc url("/images/foo.png") no-repeat left top;margin: 1em !important;padding: 2px 6px 3px;}';
         $this->assertSame($sExpected, $oDoc->render());
         $oDoc->expandShorthands();
-        $sExpected = 'body {margin-top: 1em !important;margin-right: 1em !important;margin-bottom: 1em !important;margin-left: 1em !important;padding-top: 2px;padding-right: 6px;padding-bottom: 3px;padding-left: 6px;border-top-color: #f0f;border-right-color: #f0f;border-bottom-color: #f0f;border-left-color: #f0f;border-top-style: solid;border-right-style: solid;border-bottom-style: solid;border-left-style: solid;border-top-width: 2px;border-right-width: 2px;border-bottom-width: 2px;border-left-width: 2px;font-style: italic;font-variant: normal;font-weight: 500;font-size: 14px;line-height: 1.618;font-family: "Trebuchet MS",Georgia,serif;background-color: #ccc;background-image: url("/images/foo.png");background-repeat: no-repeat;background-attachment: scroll;background-position: left top;}';
+        $sExpected =
+            'body {margin-top: 1em !important;margin-right: 1em !important;margin-bottom: 1em !important;margin-left: 1em !important;padding-top: 2px;padding-right: 6px;padding-bottom: 3px;padding-left: 6px;border-top-color: #f0f;border-right-color: #f0f;border-bottom-color: #f0f;border-left-color: #f0f;border-top-style: solid;border-right-style: solid;border-bottom-style: solid;border-left-style: solid;border-top-width: 2px;border-right-width: 2px;border-bottom-width: 2px;border-left-width: 2px;font-style: italic;font-variant: normal;font-weight: 500;font-size: 14px;line-height: 1.618;font-family: "Trebuchet MS",Georgia,serif;background-color: #ccc;background-image: url("/images/foo.png");background-repeat: no-repeat;background-attachment: scroll;background-position: left top;}';
         $this->assertSame($sExpected, $oDoc->render());
     }
 
     public function testCreateShorthands()
     {
         $oDoc = $this->parsedStructureForFile('create-shorthands');
-        $sExpected = 'body {font-size: 2em;font-family: Helvetica,Arial,sans-serif;font-weight: bold;border-width: 2px;border-color: #999;border-style: dotted;background-color: #fff;background-image: url("foobar.png");background-repeat: repeat-y;margin-top: 2px;margin-right: 3px;margin-bottom: 4px;margin-left: 5px;}';
+        $sExpected =
+            'body {font-size: 2em;font-family: Helvetica,Arial,sans-serif;font-weight: bold;border-width: 2px;border-color: #999;border-style: dotted;background-color: #fff;background-image: url("foobar.png");background-repeat: repeat-y;margin-top: 2px;margin-right: 3px;margin-bottom: 4px;margin-left: 5px;}';
         $this->assertSame($sExpected, $oDoc->render());
         $oDoc->createShorthands();
-        $sExpected = 'body {background: #fff url("foobar.png") repeat-y;margin: 2px 5px 4px 3px;border: 2px dotted #999;font: bold 2em Helvetica,Arial,sans-serif;}';
+        $sExpected =
+            'body {background: #fff url("foobar.png") repeat-y;margin: 2px 5px 4px 3px;border: 2px dotted #999;font: bold 2em Helvetica,Arial,sans-serif;}';
         $this->assertSame($sExpected, $oDoc->render());
     }
 
@@ -396,8 +441,8 @@ foo|test {gaga: 1;}
     }
 
     /**
-    * @expectedException Sabberworm\CSS\Parsing\OutputException
-    */
+     * @expectedException Sabberworm\CSS\Parsing\OutputException
+     */
     public function testSelectorRemoval()
     {
         $oDoc = $this->parsedStructureForFile('1readme');
@@ -459,7 +504,8 @@ div {width: calc(50% - ( ( 4% ) * .5 ));}';
     public function testGridLineNameInFile()
     {
         $oDoc = $this->parsedStructureForFile('grid-linename', Settings::create()->withMultibyteSupport(true));
-        $sExpected = "div {grid-template-columns: [linename] 100px;}\nspan {grid-template-columns: [linename1 linename2] 100px;}";
+        $sExpected =
+            "div {grid-template-columns: [linename] 100px;}\nspan {grid-template-columns: [linename1 linename2] 100px;}";
         $this->assertSame($sExpected, $oDoc->render());
     }
 
@@ -522,7 +568,8 @@ body {background-color: red;}';
     public function testIdentifierEscapesInFile()
     {
         $oDoc = $this->parsedStructureForFile('identifier-escapes', Settings::create()->withMultibyteSupport(true));
-        $sExpected = 'div {font: 14px Font Awesome\ 5 Pro;font: 14px Font Awesome\} 5 Pro;font: 14px Font Awesome\; 5 Pro;f\;ont: 14px Font Awesome\; 5 Pro;}';
+        $sExpected =
+            'div {font: 14px Font Awesome\ 5 Pro;font: 14px Font Awesome\} 5 Pro;font: 14px Font Awesome\; 5 Pro;f\;ont: 14px Font Awesome\; 5 Pro;}';
         $this->assertSame($sExpected, $oDoc->render());
     }
 
@@ -537,7 +584,11 @@ body {background-color: red;}';
 
     public function testKeyframeSelectors()
     {
-        $oDoc = $this->parsedStructureForFile('keyframe-selector-validation', Settings::create()->withMultibyteSupport(true));
+        $oDoc =
+            $this->parsedStructureForFile(
+                'keyframe-selector-validation',
+                Settings::create()->withMultibyteSupport(true)
+            );
         $sExpected = '@-webkit-keyframes zoom {0% {-webkit-transform: scale(1,1);}
 	50% {-webkit-transform: scale(1.2,1.2);}
 	100% {-webkit-transform: scale(1,1);}}';
@@ -545,16 +596,16 @@ body {background-color: red;}';
     }
 
     /**
-    * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
-    */
+     * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
+     */
     public function testLineNameFailure()
     {
         $this->parsedStructureForFile('-empty-grid-linename', Settings::create()->withLenientParsing(false));
     }
 
     /**
-    * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
-    */
+     * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
+     */
     public function testCalcFailure()
     {
         $this->parsedStructureForFile('-calc-no-space-around-minus', Settings::create()->withLenientParsing(false));
@@ -661,7 +712,7 @@ body {background-url: url("https://somesite.com/images/someimage.gif");}';
     /**
      * Parse structure for file.
      *
-     * @param string      $sFileName Filename.
+     * @param string $sFileName Filename.
      * @param null|obJeCt $oSettings Settings.
      *
      * @return CSSList\Document Parsed document.
@@ -688,7 +739,7 @@ body {background-url: url("https://somesite.com/images/someimage.gif");}';
             // Line Numbers of the inner declaration blocks
             17 => [KeyFrame::class, 18, 20],
             23 => [Import::class],
-            25 => [DeclarationBlock::class]
+            25 => [DeclarationBlock::class],
         ];
 
         $aActual = [];
@@ -730,7 +781,8 @@ body {background-url: url("https://somesite.com/images/someimage.gif");}';
 
     /**
      * @expectedException \Sabberworm\CSS\Parsing\UnexpectedTokenException
-     * Credit: This test by @sabberworm (from https://github.com/sabberworm/PHP-CSS-Parser/pull/105#issuecomment-229643910 )
+     * Credit: This test by @sabberworm (from
+     *     https://github.com/sabberworm/PHP-CSS-Parser/pull/105#issuecomment-229643910 )
      */
     public function testUnexpectedTokenExceptionLineNo()
     {
@@ -744,8 +796,8 @@ body {background-url: url("https://somesite.com/images/someimage.gif");}';
     }
 
     /**
-    * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
-    */
+     * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
+     */
     public function testIeHacksStrictParsing()
     {
         // We can't strictly parse IE hacks.
@@ -755,7 +807,8 @@ body {background-url: url("https://somesite.com/images/someimage.gif");}';
     public function testIeHacksParsing()
     {
         $oDoc = $this->parsedStructureForFile('ie-hacks', Settings::create()->withLenientParsing(true));
-        $sExpected = 'p {padding-right: .75rem \9;background-image: none \9;color: red \9\0;background-color: red \9\0;background-color: red \9\0 !important;content: "red 	\0";content: "red઼";}';
+        $sExpected =
+            'p {padding-right: .75rem \9;background-image: none \9;color: red \9\0;background-color: red \9\0;background-color: red \9\0 !important;content: "red 	\0";content: "red઼";}';
         $this->assertEquals($sExpected, $oDoc->render());
     }
 
@@ -826,8 +879,8 @@ body {background-url: url("https://somesite.com/images/someimage.gif");}';
     }
 
     /**
-    * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
-    */
+     * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
+     */
     public function testMicrosoftFilterStrictParsing()
     {
         $oDoc = $this->parsedStructureForFile('ms-filter', Settings::create()->beStrict());
@@ -836,7 +889,8 @@ body {background-url: url("https://somesite.com/images/someimage.gif");}';
     public function testMicrosoftFilterParsing()
     {
         $oDoc = $this->parsedStructureForFile('ms-filter');
-        $sExpected = ".test {filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=\"#80000000\",endColorstr=\"#00000000\",GradientType=1);}";
+        $sExpected =
+            ".test {filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=\"#80000000\",endColorstr=\"#00000000\",GradientType=1);}";
         $this->assertSame($sExpected, $oDoc->render());
     }
 

--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -19,7 +19,7 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->expandBorderShorthand();
         }
-        $this->assertSame(trim((string) $oDoc), $sExpected);
+        $this->assertSame(trim((string)$oDoc), $sExpected);
     }
 
     public function expandBorderShorthandProvider()
@@ -30,7 +30,7 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
             ['body{ border: 2px }', 'body {border-width: 2px;}'],
             ['body{ border: #f00 }', 'body {border-color: #f00;}'],
             ['body{ border: 1em solid }', 'body {border-width: 1em;border-style: solid;}'],
-            ['body{ margin: 1em; }', 'body {margin: 1em;}']
+            ['body{ margin: 1em; }', 'body {margin: 1em;}'],
         ];
     }
 
@@ -44,7 +44,7 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->expandFontShorthand();
         }
-        $this->assertSame(trim((string) $oDoc), $sExpected);
+        $this->assertSame(trim((string)$oDoc), $sExpected);
     }
 
     public function expandFontShorthandProvider()
@@ -52,27 +52,27 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         return [
             [
                 'body{ margin: 1em; }',
-                'body {margin: 1em;}'
+                'body {margin: 1em;}',
             ],
             [
                 'body {font: 12px serif;}',
-                'body {font-style: normal;font-variant: normal;font-weight: normal;font-size: 12px;line-height: normal;font-family: serif;}'
+                'body {font-style: normal;font-variant: normal;font-weight: normal;font-size: 12px;line-height: normal;font-family: serif;}',
             ],
             [
                 'body {font: italic 12px serif;}',
-                'body {font-style: italic;font-variant: normal;font-weight: normal;font-size: 12px;line-height: normal;font-family: serif;}'
+                'body {font-style: italic;font-variant: normal;font-weight: normal;font-size: 12px;line-height: normal;font-family: serif;}',
             ],
             [
                 'body {font: italic bold 12px serif;}',
-                'body {font-style: italic;font-variant: normal;font-weight: bold;font-size: 12px;line-height: normal;font-family: serif;}'
+                'body {font-style: italic;font-variant: normal;font-weight: bold;font-size: 12px;line-height: normal;font-family: serif;}',
             ],
             [
                 'body {font: italic bold 12px/1.6 serif;}',
-                'body {font-style: italic;font-variant: normal;font-weight: bold;font-size: 12px;line-height: 1.6;font-family: serif;}'
+                'body {font-style: italic;font-variant: normal;font-weight: bold;font-size: 12px;line-height: 1.6;font-family: serif;}',
             ],
             [
                 'body {font: italic small-caps bold 12px/1.6 serif;}',
-                'body {font-style: italic;font-variant: small-caps;font-weight: bold;font-size: 12px;line-height: 1.6;font-family: serif;}'
+                'body {font-style: italic;font-variant: small-caps;font-weight: bold;font-size: 12px;line-height: 1.6;font-family: serif;}',
             ],
         ];
     }
@@ -87,18 +87,33 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->expandBackgroundShorthand();
         }
-        $this->assertSame(trim((string) $oDoc), $sExpected);
+        $this->assertSame(trim((string)$oDoc), $sExpected);
     }
 
     public function expandBackgroundShorthandProvider()
     {
         return [
             ['body {border: 1px;}', 'body {border: 1px;}'],
-            ['body {background: #f00;}', 'body {background-color: #f00;background-image: none;background-repeat: repeat;background-attachment: scroll;background-position: 0% 0%;}'],
-            ['body {background: #f00 url("foobar.png");}', 'body {background-color: #f00;background-image: url("foobar.png");background-repeat: repeat;background-attachment: scroll;background-position: 0% 0%;}'],
-            ['body {background: #f00 url("foobar.png") no-repeat;}', 'body {background-color: #f00;background-image: url("foobar.png");background-repeat: no-repeat;background-attachment: scroll;background-position: 0% 0%;}'],
-            ['body {background: #f00 url("foobar.png") no-repeat center;}', 'body {background-color: #f00;background-image: url("foobar.png");background-repeat: no-repeat;background-attachment: scroll;background-position: center center;}'],
-            ['body {background: #f00 url("foobar.png") no-repeat top left;}', 'body {background-color: #f00;background-image: url("foobar.png");background-repeat: no-repeat;background-attachment: scroll;background-position: top left;}'],
+            [
+                'body {background: #f00;}',
+                'body {background-color: #f00;background-image: none;background-repeat: repeat;background-attachment: scroll;background-position: 0% 0%;}',
+            ],
+            [
+                'body {background: #f00 url("foobar.png");}',
+                'body {background-color: #f00;background-image: url("foobar.png");background-repeat: repeat;background-attachment: scroll;background-position: 0% 0%;}',
+            ],
+            [
+                'body {background: #f00 url("foobar.png") no-repeat;}',
+                'body {background-color: #f00;background-image: url("foobar.png");background-repeat: no-repeat;background-attachment: scroll;background-position: 0% 0%;}',
+            ],
+            [
+                'body {background: #f00 url("foobar.png") no-repeat center;}',
+                'body {background-color: #f00;background-image: url("foobar.png");background-repeat: no-repeat;background-attachment: scroll;background-position: center center;}',
+            ],
+            [
+                'body {background: #f00 url("foobar.png") no-repeat top left;}',
+                'body {background-color: #f00;background-image: url("foobar.png");background-repeat: no-repeat;background-attachment: scroll;background-position: top left;}',
+            ],
         ];
     }
 
@@ -112,7 +127,7 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->expandDimensionsShorthand();
         }
-        $this->assertSame(trim((string) $oDoc), $sExpected);
+        $this->assertSame(trim((string)$oDoc), $sExpected);
     }
 
     public function expandDimensionsShorthandProvider()
@@ -121,8 +136,14 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
             ['body {border: 1px;}', 'body {border: 1px;}'],
             ['body {margin-top: 1px;}', 'body {margin-top: 1px;}'],
             ['body {margin: 1em;}', 'body {margin-top: 1em;margin-right: 1em;margin-bottom: 1em;margin-left: 1em;}'],
-            ['body {margin: 1em 2em;}', 'body {margin-top: 1em;margin-right: 2em;margin-bottom: 1em;margin-left: 2em;}'],
-            ['body {margin: 1em 2em 3em;}', 'body {margin-top: 1em;margin-right: 2em;margin-bottom: 3em;margin-left: 2em;}'],
+            [
+                'body {margin: 1em 2em;}',
+                'body {margin-top: 1em;margin-right: 2em;margin-bottom: 1em;margin-left: 2em;}',
+            ],
+            [
+                'body {margin: 1em 2em 3em;}',
+                'body {margin-top: 1em;margin-right: 2em;margin-bottom: 3em;margin-left: 2em;}',
+            ],
         ];
     }
 
@@ -136,7 +157,7 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->createBorderShorthand();
         }
-        $this->assertSame(trim((string) $oDoc), $sExpected);
+        $this->assertSame(trim((string)$oDoc), $sExpected);
     }
 
     public function createBorderShorthandProvider()
@@ -145,7 +166,7 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
             ['body {border-width: 2px;border-style: solid;border-color: #000;}', 'body {border: 2px solid #000;}'],
             ['body {border-style: none;}', 'body {border: none;}'],
             ['body {border-width: 1em;border-style: solid;}', 'body {border: 1em solid;}'],
-            ['body {margin: 1em;}', 'body {margin: 1em;}']
+            ['body {margin: 1em;}', 'body {margin: 1em;}'],
         ];
     }
 
@@ -159,7 +180,7 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->createFontShorthand();
         }
-        $this->assertSame(trim((string) $oDoc), $sExpected);
+        $this->assertSame(trim((string)$oDoc), $sExpected);
     }
 
     public function createFontShorthandProvider()
@@ -167,10 +188,19 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         return [
             ['body {font-size: 12px; font-family: serif}', 'body {font: 12px serif;}'],
             ['body {font-size: 12px; font-family: serif; font-style: italic;}', 'body {font: italic 12px serif;}'],
-            ['body {font-size: 12px; font-family: serif; font-style: italic; font-weight: bold;}', 'body {font: italic bold 12px serif;}'],
-            ['body {font-size: 12px; font-family: serif; font-style: italic; font-weight: bold; line-height: 1.6;}', 'body {font: italic bold 12px/1.6 serif;}'],
-            ['body {font-size: 12px; font-family: serif; font-style: italic; font-weight: bold; line-height: 1.6; font-variant: small-caps;}', 'body {font: italic small-caps bold 12px/1.6 serif;}'],
-            ['body {margin: 1em;}', 'body {margin: 1em;}']
+            [
+                'body {font-size: 12px; font-family: serif; font-style: italic; font-weight: bold;}',
+                'body {font: italic bold 12px serif;}',
+            ],
+            [
+                'body {font-size: 12px; font-family: serif; font-style: italic; font-weight: bold; line-height: 1.6;}',
+                'body {font: italic bold 12px/1.6 serif;}',
+            ],
+            [
+                'body {font-size: 12px; font-family: serif; font-style: italic; font-weight: bold; line-height: 1.6; font-variant: small-caps;}',
+                'body {font: italic small-caps bold 12px/1.6 serif;}',
+            ],
+            ['body {margin: 1em;}', 'body {margin: 1em;}'],
         ];
     }
 
@@ -184,7 +214,7 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->createDimensionsShorthand();
         }
-        $this->assertSame(trim((string) $oDoc), $sExpected);
+        $this->assertSame(trim((string)$oDoc), $sExpected);
     }
 
     public function createDimensionsShorthandProvider()
@@ -193,8 +223,14 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
             ['body {border: 1px;}', 'body {border: 1px;}'],
             ['body {margin-top: 1px;}', 'body {margin-top: 1px;}'],
             ['body {margin-top: 1em; margin-right: 1em; margin-bottom: 1em; margin-left: 1em;}', 'body {margin: 1em;}'],
-            ['body {margin-top: 1em; margin-right: 2em; margin-bottom: 1em; margin-left: 2em;}', 'body {margin: 1em 2em;}'],
-            ['body {margin-top: 1em; margin-right: 2em; margin-bottom: 3em; margin-left: 2em;}', 'body {margin: 1em 2em 3em;}'],
+            [
+                'body {margin-top: 1em; margin-right: 2em; margin-bottom: 1em; margin-left: 2em;}',
+                'body {margin: 1em 2em;}',
+            ],
+            [
+                'body {margin-top: 1em; margin-right: 2em; margin-bottom: 3em; margin-left: 2em;}',
+                'body {margin: 1em 2em 3em;}',
+            ],
         ];
     }
 
@@ -208,7 +244,7 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         foreach ($oDoc->getAllDeclarationBlocks() as $oDeclaration) {
             $oDeclaration->createBackgroundShorthand();
         }
-        $this->assertSame(trim((string) $oDoc), $sExpected);
+        $this->assertSame(trim((string)$oDoc), $sExpected);
     }
 
     public function createBackgroundShorthandProvider()
@@ -216,11 +252,26 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         return [
             ['body {border: 1px;}', 'body {border: 1px;}'],
             ['body {background-color: #f00;}', 'body {background: #f00;}'],
-            ['body {background-color: #f00;background-image: url(foobar.png);}', 'body {background: #f00 url("foobar.png");}'],
-            ['body {background-color: #f00;background-image: url(foobar.png);background-repeat: no-repeat;}', 'body {background: #f00 url("foobar.png") no-repeat;}'],
-            ['body {background-color: #f00;background-image: url(foobar.png);background-repeat: no-repeat;}', 'body {background: #f00 url("foobar.png") no-repeat;}'],
-            ['body {background-color: #f00;background-image: url(foobar.png);background-repeat: no-repeat;background-position: center;}', 'body {background: #f00 url("foobar.png") no-repeat center;}'],
-            ['body {background-color: #f00;background-image: url(foobar.png);background-repeat: no-repeat;background-position: top left;}', 'body {background: #f00 url("foobar.png") no-repeat top left;}'],
+            [
+                'body {background-color: #f00;background-image: url(foobar.png);}',
+                'body {background: #f00 url("foobar.png");}',
+            ],
+            [
+                'body {background-color: #f00;background-image: url(foobar.png);background-repeat: no-repeat;}',
+                'body {background: #f00 url("foobar.png") no-repeat;}',
+            ],
+            [
+                'body {background-color: #f00;background-image: url(foobar.png);background-repeat: no-repeat;}',
+                'body {background: #f00 url("foobar.png") no-repeat;}',
+            ],
+            [
+                'body {background-color: #f00;background-image: url(foobar.png);background-repeat: no-repeat;background-position: center;}',
+                'body {background: #f00 url("foobar.png") no-repeat center;}',
+            ],
+            [
+                'body {background-color: #f00;background-image: url(foobar.png);background-repeat: no-repeat;background-position: top left;}',
+                'body {background: #f00 url("foobar.png") no-repeat top left;}',
+            ],
         ];
     }
 
@@ -280,7 +331,10 @@ class DeclarationBlockTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($oSecond, $aRules[3]);
         $this->assertSame($oAfter, $aRules[4]);
 
-        $this->assertSame('.wrapper {left: 16em;left: 10px;text-align: 1;text-align: left;border-bottom-width: 1px;}', $oDoc->render());
+        $this->assertSame(
+            '.wrapper {left: 16em;left: 10px;text-align: 1;text-align: left;border-bottom-width: 1px;}',
+            $oDoc->render()
+        );
     }
 
     public function testOrderOfElementsMatchingOriginalOrderAfterExpandingShorthands()

--- a/tests/RuleSet/LenientParsingTest.php
+++ b/tests/RuleSet/LenientParsingTest.php
@@ -9,8 +9,8 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
 {
 
     /**
-    * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
-    */
+     * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
+     */
     public function testFaultToleranceOff()
     {
         $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-fault-tolerance.css";
@@ -24,14 +24,15 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
         $oResult = $oParser->parse();
         $this->assertSame(
-            '.test1 {}' . "\n" . '.test2 {hello: 2.2;hello: 2000000000000.2;}' . "\n" . '#test {}' . "\n" . '#test2 {help: none;}',
+            '.test1 {}' . "\n" . '.test2 {hello: 2.2;hello: 2000000000000.2;}' . "\n" . '#test {}' . "\n"
+            . '#test2 {help: none;}',
             $oResult->render()
         );
     }
 
     /**
-    * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
-    */
+     * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
+     */
     public function testEndToken()
     {
         $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-end-token.css";
@@ -40,8 +41,8 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
-    */
+     * @expectedException Sabberworm\CSS\Parsing\UnexpectedTokenException
+     */
     public function testEndToken2()
     {
         $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-end-token-2.css";
@@ -62,7 +63,10 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
         $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-end-token-2.css";
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
         $oResult = $oParser->parse();
-        $this->assertSame('#home .bg-layout {background-image: url("/bundles/main/img/bg1.png?5");}', $oResult->render());
+        $this->assertSame(
+            '#home .bg-layout {background-image: url("/bundles/main/img/bg1.png?5");}',
+            $oResult->render()
+        );
     }
 
     public function testLocaleTrap()
@@ -72,7 +76,8 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
         $oResult = $oParser->parse();
         $this->assertSame(
-            '.test1 {}' . "\n" . '.test2 {hello: 2.2;hello: 2000000000000.2;}' . "\n" . '#test {}' . "\n" . '#test2 {help: none;}',
+            '.test1 {}' . "\n" . '.test2 {hello: 2.2;hello: 2000000000000.2;}' . "\n" . '#test {}' . "\n"
+            . '#test2 {help: none;}',
             $oResult->render()
         );
     }
@@ -82,9 +87,12 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
         $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "case-insensitivity.css";
         $oParser = new Parser(file_get_contents($sFile));
         $oResult = $oParser->parse();
-        $this->assertSame('@charset "utf-8";
+        $this->assertSame(
+            '@charset "utf-8";
 @import url("test.css");
 @media screen {}
-#myid {case: insensitive !important;frequency: 30Hz;font-size: 1em;color: #ff0;color: hsl(40,40%,30%);font-family: Arial;}', $oResult->render());
+#myid {case: insensitive !important;frequency: 30Hz;font-size: 1em;color: #ff0;color: hsl(40,40%,30%);font-family: Arial;}',
+            $oResult->render()
+        );
     }
 }


### PR DESCRIPTION
This allows contributors to autoformat their changed files without
risking to also affect the unchanged code.

This change also fixes a bunch of PSR-12 violations, and it hopefully
also makes the code a bit nicer to read.