### PR TITLE
Move the quickdump tool out of the `tests` directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 /.gitignore export-ignore
 /.phive/ export-ignore
 /Doxyfile export-ignore
+/bin/ export-ignore
 /phpcs.xml export-ignore
 /phpstan-baseline.neon export-ignore
 /phpstan.neon.dist export-ignore

--- a/bin/quickdump.php
+++ b/bin/quickdump.php
@@ -1,7 +1,11 @@
 #!/usr/bin/env php
 <?php
 
-require_once(__DIR__ . '/bootstrap.php');
+/**
+ * This script is used for generating the examples in the README.
+ */
+
+require_once(__DIR__ . '/../vendor/autoload.php');
 
 $sSource = file_get_contents('php://stdin');
 $oParser = new Sabberworm\CSS\Parser($sSource);

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ci": [
             "@ci:static"
         ],
-        "ci:php:sniff": "@php ./.phive/phpcs.phar src tests",
+        "ci:php:sniff": "@php ./.phive/phpcs.phar bin src tests",
         "ci:php:stan": "@php ./.phive/phpstan.phar",
         "ci:static": [
             "@ci:php:sniff",
@@ -31,7 +31,7 @@
         "fix:php": [
             "@fix:php:sniff"
         ],
-        "fix:php:sniff": "@php ./.phive/phpcbf.phar src tests",
+        "fix:php:sniff": "@php ./.phive/phpcbf.phar bin src tests",
         "phpstan:baseline": "@php ./.phive/phpstan.phar --generate-baseline"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,8 +9,10 @@ parameters:
   level: 1
 
   scanDirectories:
+    - %currentWorkingDirectory%/bin/
     - %currentWorkingDirectory%/src/
     - %currentWorkingDirectory%/tests/
   paths:
+    - %currentWorkingDirectory%/bin/
     - %currentWorkingDirectory%/src/
     - %currentWorkingDirectory%/tests/


### PR DESCRIPTION
This tool is not related to the tests and hence should not be stored
in the `tests`  directory.

Also properly include the Composer autoload and add a short comment
explaning the purpose of the file.