### PR TITLE
Add array parameter type declarations

### DIFF
--- a/src/CSSList/CSSBlockList.php
+++ b/src/CSSList/CSSBlockList.php
@@ -19,7 +19,7 @@ abstract class CSSBlockList extends CSSList
         parent::__construct($iLineNo);
     }
 
-    protected function allDeclarationBlocks(&$aResult)
+    protected function allDeclarationBlocks(array &$aResult)
     {
         foreach ($this->aContents as $mContent) {
             if ($mContent instanceof DeclarationBlock) {
@@ -30,7 +30,7 @@ abstract class CSSBlockList extends CSSList
         }
     }
 
-    protected function allRuleSets(&$aResult)
+    protected function allRuleSets(array &$aResult)
     {
         foreach ($this->aContents as $mContent) {
             if ($mContent instanceof RuleSet) {
@@ -41,7 +41,7 @@ abstract class CSSBlockList extends CSSList
         }
     }
 
-    protected function allValues($oElement, &$aResult, $sSearchString = null, $bSearchInFunctionArguments = false)
+    protected function allValues($oElement, array &$aResult, $sSearchString = null, $bSearchInFunctionArguments = false)
     {
         if ($oElement instanceof CSSBlockList) {
             foreach ($oElement->getContents() as $oContent) {
@@ -65,7 +65,7 @@ abstract class CSSBlockList extends CSSList
         }
     }
 
-    protected function allSelectors(&$aResult, $sSpecificitySearch = null)
+    protected function allSelectors(array &$aResult, $sSpecificitySearch = null)
     {
         $aDeclarationBlocks = [];
         $this->allDeclarationBlocks($aDeclarationBlocks);

--- a/src/OutputFormat.php
+++ b/src/OutputFormat.php
@@ -102,6 +102,9 @@ class OutputFormat
         return null;
     }
 
+    /**
+     * @param array<array-key, string>|string $aNames
+     */
     public function set($aNames, $mValue)
     {
         $aVarPrefixes = ['a', 's', 'm', 'b', 'f', 'o', 'c', 'i'];
@@ -132,7 +135,7 @@ class OutputFormat
         return false;
     }
 
-    public function __call($sMethodName, $aArguments)
+    public function __call($sMethodName, array $aArguments)
     {
         if (strpos($sMethodName, 'set') === 0) {
             return $this->set(substr($sMethodName, 3), $aArguments[0]);

--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -109,7 +109,7 @@ class OutputFormatter
     /**
      * Clone of the implode function but calls ->render with the current output format instead of ` __toString()
      */
-    public function implode($sSeparator, $aValues, $bIncreaseLevel = false)
+    public function implode($sSeparator, array $aValues, $bIncreaseLevel = false)
     {
         $sResult = '';
         $oFormat = $this->oFormat;

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -242,6 +242,9 @@ class ParserState
         return $this->iCurrentPosition >= $this->iLength;
     }
 
+    /**
+     * @param array<array-key, string>|string $aEnd
+     */
     public function consumeUntil($aEnd, $bIncludeEnd = false, $consumeEnd = false, array &$comments = [])
     {
         $aEnd = is_array($aEnd) ? $aEnd : [$aEnd];

--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -130,7 +130,7 @@ class Rule implements Renderable, Commentable
      * @deprecated Old-Style 2-dimensional array given. Retained for (some) backwards-compatibility.
      *              Use setValue() instead and wrap the value inside a RuleValueList if necessary.
      */
-    public function setValues($aSpaceSeparatedValues)
+    public function setValues(array $aSpaceSeparatedValues)
     {
         $oSpaceSeparatedList = null;
         if (count($aSpaceSeparatedValues) > 1) {

--- a/src/Value/CSSFunction.php
+++ b/src/Value/CSSFunction.php
@@ -7,6 +7,9 @@ class CSSFunction extends ValueList
 
     protected $sName;
 
+    /**
+     * @param RuleValueList|array $aArguments
+     */
     public function __construct($sName, $aArguments, $sSeparator = ',', $iLineNo = 0)
     {
         if ($aArguments instanceof RuleValueList) {

--- a/src/Value/Color.php
+++ b/src/Value/Color.php
@@ -7,7 +7,7 @@ use Sabberworm\CSS\Parsing\ParserState;
 class Color extends CSSFunction
 {
 
-    public function __construct($aColor, $iLineNo = 0)
+    public function __construct(array $aColor, $iLineNo = 0)
     {
         parent::__construct(implode('', array_keys($aColor)), $aColor, ',', $iLineNo);
     }
@@ -94,7 +94,7 @@ class Color extends CSSFunction
         return $this->aComponents;
     }
 
-    public function setColor($aColor)
+    public function setColor(array $aColor)
     {
         $this->setName(implode('', array_keys($aColor)));
         $this->aComponents = $aColor;

--- a/src/Value/LineName.php
+++ b/src/Value/LineName.php
@@ -7,7 +7,7 @@ use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 
 class LineName extends ValueList
 {
-    public function __construct($aComponents = [], $iLineNo = 0)
+    public function __construct(array $aComponents = [], $iLineNo = 0)
     {
         parent::__construct($aComponents, ' ', $iLineNo);
     }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -15,7 +15,7 @@ abstract class Value implements Renderable
         $this->iLineNo = $iLineNo;
     }
 
-    public static function parseValue(ParserState $oParserState, $aListDelimiters = [])
+    public static function parseValue(ParserState $oParserState, array $aListDelimiters = [])
     {
         $aStack = [];
         $oParserState->consumeWhiteSpace();

--- a/src/Value/ValueList.php
+++ b/src/Value/ValueList.php
@@ -9,6 +9,9 @@ abstract class ValueList extends Value
 
     protected $sSeparator;
 
+    /**
+     * @param array|mixed $aComponents
+     */
     public function __construct($aComponents = [], $sSeparator = ',', $iLineNo = 0)
     {
         parent::__construct($iLineNo);
@@ -29,7 +32,7 @@ abstract class ValueList extends Value
         return $this->aComponents;
     }
 
-    public function setListComponents($aComponents)
+    public function setListComponents(array $aComponents)
     {
         $this->aComponents = $aComponents;
     }


### PR DESCRIPTION
Also add PHPDoc type annotations for parameters that have a name
implying that they should be an array, but that actually can also
be other types.