### PR TITLE
Run the code sniffer in the CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,12 +79,23 @@ jobs:
         run: |
           ./vendor/bin/codacycoverage clover build/coverage/xml
 
-  phpstan:
-    name: PHPStan
+  static-analysis:
+    name: Static Analysis
 
     runs-on: ubuntu-20.04
 
     needs: [ php-lint ]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - command: sniff
+            tool: phpcs
+            php-version: 7.4
+          - command: stan
+            tool: phpstan
+            php-version: 7.4
 
     steps:
       - name: Checkout
@@ -93,7 +104,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: ${{ matrix.php-version }}
           tools: "composer:v2, phive"
           coverage: none
 
@@ -112,7 +123,8 @@ jobs:
 
       - name: Install development tools
         run: |
-          echo y | phive --no-progress update phpstan;
+          # These workarounds are needed until PHIVE can do installs in a non-interactive way
+          echo y | phive --no-progress update ${{ matrix.tool }};
 
-      - name: Run PHPStan
-        run: "composer ci:php:stan"
+      - name: Run Command
+        run: composer ci:php:${{ matrix.command }}


### PR DESCRIPTION
Now that the code is PSR-12-compliant, we should run the code sniffer
in the CI pipeline to keep pull request from introducing new
code style issues.