### PR TITLE
Drop pointless abstract methods

### DIFF
--- a/src/Renderable.php
+++ b/src/Renderable.php
@@ -4,6 +4,9 @@ namespace Sabberworm\CSS;
 
 interface Renderable
 {
+    /**
+     * @return string
+     */
     public function __toString();
 
     /**

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -151,8 +151,4 @@ abstract class Value implements Renderable
     {
         return $this->iLineNo;
     }
-
-    //Methods are commented out because re-declaring them here is a fatal error in PHP < 5.3.9
-    //public abstract function __toString();
-    //public abstract function render(\Sabberworm\CSS\OutputFormat $oOutputFormat);
 }


### PR DESCRIPTION
Abstract methods that duplicate what already is required by the
implementing interface do not add any value.

Also add a type annotation to the interface.