### PR TITLE
Add `@covers` annotations to the tests

### DIFF
--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\OutputFormat;
 use Sabberworm\CSS\Parser;
 
+/**
+ * @covers \Sabberworm\CSS\OutputFormat
+ */
 class OutputFormatTest extends TestCase
 {
     /**

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -19,6 +19,18 @@ use Sabberworm\CSS\Value\Color;
 use Sabberworm\CSS\Value\Size;
 use Sabberworm\CSS\Value\URL;
 
+/**
+ * @covers \Sabberworm\CSS\Parser
+ * @covers \Sabberworm\CSS\CSSList\Document::parse
+ * @covers \Sabberworm\CSS\Rule\Rule::parse
+ * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock::parse
+ * @covers \Sabberworm\CSS\Value\CalcFunction::parse
+ * @covers \Sabberworm\CSS\Value\Color::parse
+ * @covers \Sabberworm\CSS\Value\CSSString::parse
+ * @covers \Sabberworm\CSS\Value\LineName::parse
+ * @covers \Sabberworm\CSS\Value\Size::parse
+ * @covers \Sabberworm\CSS\Value\URL::parse
+ */
 class ParserTest extends TestCase
 {
     public function testFiles()

--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -7,6 +7,9 @@ use Sabberworm\CSS\Parser;
 use Sabberworm\CSS\Rule\Rule;
 use Sabberworm\CSS\Value\Size;
 
+/**
+ * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock
+ */
 class DeclarationBlockTest extends TestCase
 {
     /**

--- a/tests/RuleSet/LenientParsingTest.php
+++ b/tests/RuleSet/LenientParsingTest.php
@@ -6,6 +6,18 @@ use PHPUnit\Framework\TestCase;
 use Sabberworm\CSS\Parser;
 use Sabberworm\CSS\Settings;
 
+/**
+ * @covers \Sabberworm\CSS\Parser
+ * @covers \Sabberworm\CSS\CSSList\Document::parse
+ * @covers \Sabberworm\CSS\Rule\Rule::parse
+ * @covers \Sabberworm\CSS\RuleSet\DeclarationBlock::parse
+ * @covers \Sabberworm\CSS\Value\CalcFunction::parse
+ * @covers \Sabberworm\CSS\Value\Color::parse
+ * @covers \Sabberworm\CSS\Value\CSSString::parse
+ * @covers \Sabberworm\CSS\Value\LineName::parse
+ * @covers \Sabberworm\CSS\Value\Size::parse
+ * @covers \Sabberworm\CSS\Value\URL::parse
+ */
 class LenientParsingTest extends TestCase
 {
     /**


### PR DESCRIPTION
These make sure that only the lines of the classes the testcases are
about are marked as covered, hence reducing false coverage.