### PR TITLE
Stop using `DIRECTORY_SEPARATOR` in the tests

### DIFF
--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -37,7 +37,7 @@ class ParserTest extends \PHPUnit\Framework\TestCase
                     // or a future test of a as-of-now missing feature
                     continue;
                 }
-                $oParser = new Parser(file_get_contents($sDirectory . DIRECTORY_SEPARATOR . $sFileName));
+                $oParser = new Parser(file_get_contents($sDirectory . '/' . $sFileName));
                 try {
                     $this->assertNotEquals('', $oParser->parse()->render());
                 } catch (\Exception $e) {
@@ -807,7 +807,7 @@ body {background-color: red;}';
      */
     private function parsedStructureForFile($sFileName, $oSettings = null)
     {
-        $sFile = __DIR__ . '/fixtures' . DIRECTORY_SEPARATOR . "$sFileName.css";
+        $sFile = __DIR__ . "/fixtures/$sFileName.css";
         $oParser = new Parser(file_get_contents($sFile), $oSettings);
         return $oParser->parse();
     }

--- a/tests/RuleSet/LenientParsingTest.php
+++ b/tests/RuleSet/LenientParsingTest.php
@@ -13,14 +13,14 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
      */
     public function testFaultToleranceOff()
     {
-        $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-fault-tolerance.css";
+        $sFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->beStrict());
         $oParser->parse();
     }
 
     public function testFaultToleranceOn()
     {
-        $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-fault-tolerance.css";
+        $sFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
         $oResult = $oParser->parse();
         $this->assertSame(
@@ -35,7 +35,7 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
      */
     public function testEndToken()
     {
-        $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-end-token.css";
+        $sFile = __DIR__ . '/../fixtures/-end-token.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->beStrict());
         $oParser->parse();
     }
@@ -45,14 +45,14 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
      */
     public function testEndToken2()
     {
-        $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-end-token-2.css";
+        $sFile = __DIR__ . '/../fixtures/-end-token-2.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->beStrict());
         $oParser->parse();
     }
 
     public function testEndTokenPositive()
     {
-        $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-end-token.css";
+        $sFile = __DIR__ . '/../fixtures/-end-token.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
         $oResult = $oParser->parse();
         $this->assertSame("", $oResult->render());
@@ -60,7 +60,7 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
 
     public function testEndToken2Positive()
     {
-        $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-end-token-2.css";
+        $sFile = __DIR__ . '/../fixtures/-end-token-2.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
         $oResult = $oParser->parse();
         $this->assertSame(
@@ -72,7 +72,7 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
     public function testLocaleTrap()
     {
         setlocale(LC_ALL, "pt_PT", "no");
-        $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "-fault-tolerance.css";
+        $sFile = __DIR__ . '/../fixtures/-fault-tolerance.css';
         $oParser = new Parser(file_get_contents($sFile), Settings::create()->withLenientParsing(true));
         $oResult = $oParser->parse();
         $this->assertSame(
@@ -84,7 +84,7 @@ class LenientParsingTest extends \PHPUnit\Framework\TestCase
 
     public function testCaseInsensitivity()
     {
-        $sFile = __DIR__ . '/../fixtures' . DIRECTORY_SEPARATOR . "case-insensitivity.css";
+        $sFile = __DIR__ . '/../fixtures/case-insensitivity.css';
         $oParser = new Parser(file_get_contents($sFile));
         $oResult = $oParser->parse();
 


### PR DESCRIPTION
In the affected cases, we are already using forward slashes, and hence
can use them all the time.