### PR TITLE
Add type annotations for `CalcFunction`

### DIFF
--- a/src/Value/CalcFunction.php
+++ b/src/Value/CalcFunction.php
@@ -3,13 +3,27 @@
 namespace Sabberworm\CSS\Value;
 
 use Sabberworm\CSS\Parsing\ParserState;
+use Sabberworm\CSS\Parsing\UnexpectedEOFException;
 use Sabberworm\CSS\Parsing\UnexpectedTokenException;
 
 class CalcFunction extends CSSFunction
 {
+    /**
+     * @var int
+     */
     const T_OPERAND = 1;
+
+    /**
+     * @var int
+     */
     const T_OPERATOR = 2;
 
+    /**
+     * @return CalcFunction
+     *
+     * @throws UnexpectedTokenException
+     * @throws UnexpectedEOFException
+     */
     public static function parse(ParserState $oParserState)
     {
         $aOperators = ['+', '-', '*', '/'];


### PR DESCRIPTION
This change omits type annotations that are already covered by native
type declarations.