### PR TITLE
Add PHP CS Fixer to the toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - command: sniff
+          - command: sniffer
             tool: phpcs
+            php-version: 7.4
+          - command: fixer
+            tool: php-cs-fixer
             php-version: 7.4
           - command: stan
             tool: phpstan

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.phive/*
+/.php-cs-fixer.cache
 /.php_cs.cache
 /composer.lock
 /phpstan.neon

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
+  <phar name="php-cs-fixer" version="^3.0.0" installed="3.0.0" location="./.phive/php-cs-fixer.phar" copy="false"/>
   <phar name="phpcbf" version="^3.6.0" location="./.phive/phpcbf.phar" copy="false" installed="3.6.0"/>
   <phar name="phpcs" version="^3.6.0" location="./.phive/phpcs.phar" copy="false" installed="3.6.0"/>
   <phar name="phpstan" version="^0.12.88" installed="0.12.88" location="./.phive/phpstan.phar" copy="false"/>

--- a/composer.json
+++ b/composer.json
@@ -35,25 +35,31 @@
         "ci": [
             "@ci:static"
         ],
-        "ci:php:sniff": "@php ./.phive/phpcs.phar --standard=config/phpcs.xml bin src tests",
+        "ci:php:fixer": "@php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots bin src tests",
+        "ci:php:sniffer": "@php ./.phive/phpcs.phar --standard=config/phpcs.xml bin src tests",
         "ci:php:stan": "@php ./.phive/phpstan.phar --configuration=config/phpstan.neon",
         "ci:static": [
-            "@ci:php:sniff",
+            "@ci:php:fixer",
+            "@ci:php:sniffer",
             "@ci:php:stan"
         ],
         "fix:php": [
-            "@fix:php:sniff"
+            "@fix:php:fixer",
+            "@fix:php:sniffer"
         ],
-        "fix:php:sniff": "@php ./.phive/phpcbf.phar --standard=config/phpcs.xml bin src tests",
+        "fix:php:fixer": "@php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix bin src tests",
+        "fix:php:sniffer": "@php ./.phive/phpcbf.phar --standard=config/phpcs.xml bin src tests",
         "phpstan:baseline": "@php ./.phive/phpstan.phar --configuration=config/phpstan.neon --generate-baseline=config/phpstan-baseline.neon"
     },
     "scripts-descriptions": {
         "ci": "Runs all dynamic and static code checks (i.e. currently, only the static checks).",
-        "ci:php:sniff": "Checks the code style with PHP_CodeSniffer.",
+        "ci:php:fixer": "Checks the code style with PHP CS Fixer.",
+        "ci:php:sniffer": "Checks the code style with PHP_CodeSniffer.",
         "ci:php:stan": "Checks the types with PHPStan.",
         "ci:static": "Runs all static code analysis checks for the code.",
         "fix:php": "Autofixes all autofixable issues in the PHP code.",
-        "fix:php:sniff": "Fixes autofixable issues found by PHP_CodeSniffer.",
+        "fix:php:fixer": "Fixes autofixable issues found by PHP CS Fixer.",
+        "fix:php:sniffer": "Fixes autofixable issues found by PHP_CodeSniffer.",
         "phpstand:baseline": "Updates the PHPStan baseline file to match the code."
     }
 }

--- a/config/php-cs-fixer.php
+++ b/config/php-cs-fixer.php
@@ -1,0 +1,15 @@
+<?php
+
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+
+return (new \PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules(
+        [
+            '@PSR12' => true,
+            // Disable constant visibility from the PSR12 rule set as this would break compatibility with PHP < 7.1.
+            'visibility_required' => ['elements' => ['property', 'method']],
+        ]
+    );


### PR DESCRIPTION
This tool will help detect and fix more PSR-12 issues, and it will also
help modernize the tests so that it's easier to cover issues found by
PHPStan with tests.