### PR TITLE
Add a requirement on iconv and suggest mbstring in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,15 @@
         }
     ],
     "require": {
-        "php": ">=5.6.20"
+        "php": ">=5.6.20",
+        "ext-iconv": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36",
         "codacy/coverage": "^1.4"
+    },
+    "suggest": {
+        "ext-mbstring": "for parsing UTF-8 CSS"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The iconv PHP extension is used in `ParserState` and hence needs to be
required.

The mbstring extension is optional, but helpful. So we should help
users discover this with a `suggest` entry in the `composer.json`.