### PR TITLE
Use spaces for indenting regular expressions

### DIFF
--- a/src/Property/KeyframeSelector.php
+++ b/src/Property/KeyframeSelector.php
@@ -10,14 +10,14 @@ class KeyframeSelector extends Selector
      * @var string
      */
     const SELECTOR_VALIDATION_RX = '/
-	^(
-		(?:
-			[a-zA-Z0-9\x{00A0}-\x{FFFF}_^$|*="\'~\[\]()\-\s\.:#+>]* # any sequence of valid unescaped characters
-			(?:\\\\.)?                                              # a single escaped character
-			(?:([\'"]).*?(?<!\\\\)\2)?                              # a quoted text like [id="example"]
-		)*
-	)|
-	(\d+%)                                                          # keyframe animation progress percentage (e.g. 50%)
-	$
-	/ux';
+    ^(
+        (?:
+            [a-zA-Z0-9\x{00A0}-\x{FFFF}_^$|*="\'~\[\]()\-\s\.:#+>]* # any sequence of valid unescaped characters
+            (?:\\\\.)?                                              # a single escaped character
+            (?:([\'"]).*?(?<!\\\\)\2)?                              # a quoted text like [id="example"]
+        )*
+    )|
+    (\d+%)                                                          # keyframe animation progress percentage (e.g. 50%)
+    $
+    /ux';
 }

--- a/src/Property/Selector.php
+++ b/src/Property/Selector.php
@@ -14,23 +14,23 @@ class Selector
      * @var string
      */
     const NON_ID_ATTRIBUTES_AND_PSEUDO_CLASSES_RX = '/
-	(\.[\w]+)                   # classes
-	|
-	\[(\w+)                     # attributes
-	|
-	(\:(                        # pseudo classes
-		link|visited|active
-		|hover|focus
-		|lang
-		|target
-		|enabled|disabled|checked|indeterminate
-		|root
-		|nth-child|nth-last-child|nth-of-type|nth-last-of-type
-		|first-child|last-child|first-of-type|last-of-type
-		|only-child|only-of-type
-		|empty|contains
-	))
-	/ix';
+        (\.[\w]+)                   # classes
+        |
+        \[(\w+)                     # attributes
+        |
+        (\:(                        # pseudo classes
+            link|visited|active
+            |hover|focus
+            |lang
+            |target
+            |enabled|disabled|checked|indeterminate
+            |root
+            |nth-child|nth-last-child|nth-of-type|nth-last-of-type
+            |first-child|last-child|first-of-type|last-of-type
+            |only-child|only-of-type
+            |empty|contains
+        ))
+        /ix';
 
     /**
      * regexp for specificity calculations
@@ -38,12 +38,12 @@ class Selector
      * @var string
      */
     const ELEMENTS_AND_PSEUDO_ELEMENTS_RX = '/
-	((^|[\s\+\>\~]+)[\w]+   # elements
-	|
-	\:{1,2}(                # pseudo-elements
-		after|before|first-letter|first-line|selection
-	))
-	/ix';
+        ((^|[\s\+\>\~]+)[\w]+   # elements
+        |
+        \:{1,2}(                # pseudo-elements
+            after|before|first-letter|first-line|selection
+        ))
+        /ix';
 
     /**
      * regexp for specificity calculations
@@ -51,14 +51,14 @@ class Selector
      * @var string
      */
     const SELECTOR_VALIDATION_RX = '/
-	^(
-		(?:
-			[a-zA-Z0-9\x{00A0}-\x{FFFF}_^$|*="\'~\[\]()\-\s\.:#+>]* # any sequence of valid unescaped characters
-			(?:\\\\.)?                                              # a single escaped character
-			(?:([\'"]).*?(?<!\\\\)\2)?                              # a quoted text like [id="example"]
-		)*
-	)$
-	/ux';
+        ^(
+            (?:
+                [a-zA-Z0-9\x{00A0}-\x{FFFF}_^$|*="\'~\[\]()\-\s\.:#+>]* # any sequence of valid unescaped characters
+                (?:\\\\.)?                                              # a single escaped character
+                (?:([\'"]).*?(?<!\\\\)\2)?                              # a quoted text like [id="example"]
+            )*
+        )$
+        /ux';
 
     /**
      * @var string


### PR DESCRIPTION
There is no need to use tabs here, and now the indentation is
consistent with the indentation used for the PHP code.