### PR TITLE
Also run PHP-linting with PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
+        php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1 ]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
We currently cannot run the unit tests with PHP 8.1, but at least now
we can be sure our code does not have syntax that is incompatible
with PHP 8.1.