### PR TITLE
Also allow string values for rules

### DIFF
--- a/src/Rule/Rule.php
+++ b/src/Rule/Rule.php
@@ -24,7 +24,7 @@ class Rule implements Renderable, Commentable
     private $sRule;
 
     /**
-     * @var RuleValueList|null
+     * @var RuleValueList|string|null
      */
     private $mValue;
 
@@ -171,7 +171,7 @@ class Rule implements Renderable, Commentable
     }
 
     /**
-     * @return RuleValueList|null
+     * @return RuleValueList|string|null
      */
     public function getValue()
     {
@@ -179,7 +179,7 @@ class Rule implements Renderable, Commentable
     }
 
     /**
-     * @param RuleValueList|null $mValue
+     * @param RuleValueList|string|null $mValue
      *
      * @return void
      */


### PR DESCRIPTION
Rules can have string values, and the type annotations should allow this
to avoid type analysis warnings in code using this library.