### PR TITLE
Replace invalid `turns` unit with `turn`

### DIFF
--- a/src/Value/Size.php
+++ b/src/Value/Size.php
@@ -24,7 +24,7 @@ class Size extends PrimitiveValue
     /**
      * @var array<int, string>
      */
-    const NON_SIZE_UNITS = ['deg', 'grad', 'rad', 's', 'ms', 'turns', 'Hz', 'kHz'];
+    const NON_SIZE_UNITS = ['deg', 'grad', 'rad', 's', 'ms', 'turn', 'Hz', 'kHz'];
 
     /**
      * @var array<int, array<string, string>>|null

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -360,7 +360,7 @@ class ParserTest extends TestCase
         self::assertSame(
             '#header {margin: 10px 2em 1cm 2%;font-family: Verdana,Helvetica,"Gill Sans",sans-serif;'
             . 'font-size: 10px;color: red !important;background-color: green;'
-            . 'background-color: rgba(0,128,0,.7);frequency: 30Hz;}
+            . 'background-color: rgba(0,128,0,.7);frequency: 30Hz;transform: rotate(1turn);}
 body {color: green;font: 75% "Lucida Grande","Trebuchet MS",Verdana,sans-serif;}',
             $oDoc->render()
         );
@@ -369,7 +369,7 @@ body {color: green;font: 75% "Lucida Grande","Trebuchet MS",Verdana,sans-serif;}
         }
         self::assertSame(
             '#header {margin: 10px 2em 1cm 2%;color: red !important;background-color: green;'
-            . 'background-color: rgba(0,128,0,.7);frequency: 30Hz;}
+            . 'background-color: rgba(0,128,0,.7);frequency: 30Hz;transform: rotate(1turn);}
 body {color: green;}',
             $oDoc->render()
         );
@@ -377,7 +377,7 @@ body {color: green;}',
             $oRuleSet->removeRule('background-');
         }
         self::assertSame(
-            '#header {margin: 10px 2em 1cm 2%;color: red !important;frequency: 30Hz;}
+            '#header {margin: 10px 2em 1cm 2%;color: red !important;frequency: 30Hz;transform: rotate(1turn);}
 body {color: green;}',
             $oDoc->render()
         );

--- a/tests/fixtures/values.css
+++ b/tests/fixtures/values.css
@@ -6,6 +6,7 @@
 	background-color: green;
 	background-color: rgba(0,128,0,0.7);
 	frequency: 30Hz;
+    transform: rotate(1turn);
 }
 
 body {


### PR DESCRIPTION
This fixes merge conflicts for the key change in https://github.com/sabberworm/PHP-CSS-Parser/pull/193 which replaces the invalid `turns` init with `turn`, as identified by @pierlon:

> Also, there is no such unit named `turns`, but there is one called `turn` ([ref](https://drafts.csswg.org/css-values-3/#turn)), which I suppose is what was meant here 😄.

The use of `turns` in this codebase goes back [10 years](https://github.com/sabberworm/PHP-CSS-Parser/blame/7675640abec375a6c3c99590326bd78c3a7ec45d/lib/Sabberworm/CSS/Value/Size.php#L42).