### PR TITLE
Quote all version numbers in the CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3' ]
         coverage: [ 'none' ]
         include:
-          - php-version: 7.4
+          - php-version: '7.4'
             coverage: xdebug
 
     steps:
@@ -91,11 +91,11 @@ jobs:
       matrix:
         include:
           - command: sniffer
-            php-version: 7.4
+            php-version: '7.4'
           - command: fixer
-            php-version: 7.4
+            php-version: '7.4'
           - command: stan
-            php-version: 7.4
+            php-version: '7.4'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This makes our usage of version numbers in the configuration file
consistent. It also ensures that no version number will get treated
as a number and rounded (e.g., 8.0 would have gotten rounded to 8).