### PR TITLE
Show the Composer configuration in the CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
           tools: composer:v2
           coverage: "${{ matrix.coverage }}"
 
+      - name: Show the Composer configuration
+        run: composer config --global --list
+
       - name: Cache dependencies installed with composer
         uses: actions/cache@v3
         with:
@@ -107,6 +110,9 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: "composer:v2, phive"
           coverage: none
+
+      - name: Show the Composer configuration
+        run: composer config --global --list
 
       - name: Cache dependencies installed with composer
         uses: actions/cache@v3


### PR DESCRIPTION
This helps debug problems, e.g., using an incorrect Composer cache directory.