### PR TITLE
Run the tests on CI with all warnings enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: "${{ matrix.coverage }}"
 


### PR DESCRIPTION
This allows us to catch things that will break in future PHP versions, but still kind-of-work, e.g., deprecation warnings or incorrect types.