### PR TITLE
Fix PHP8.2 str_split function returns empty arrays for empty strings

### DIFF
--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -520,7 +520,7 @@ class ParserState
             if ($sString === '') {
                 return [];
             } else {
-                return str_split($sString);
+                return mb_str_split($sString);
             }
         }
     }


### PR DESCRIPTION
In PHP 8.2, the str_split function will returns empty arrays for empty strings.
See: https://php.watch/versions/8.2/str_split-empty-string-empty-array

We can use mb_str_split() instead