### PR TITLE
Update PHPUnit to 10.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-iconv": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27",
+        "phpunit/phpunit": "^10.2",
         "codacy/coverage": "^1.4.3"
     },
     "suggest": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,14 @@
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd">
-    <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory=".phpunit.cache" bootstrap="vendor/autoload.php">
+  <coverage/>
+  <testsuites>
+    <testsuite name="Project Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/CSSList/AtRuleBlockListTest.php
+++ b/tests/CSSList/AtRuleBlockListTest.php
@@ -46,7 +46,7 @@ class AtRuleBlockListTest extends TestCase
     /**
      * @return array<string, array<int, string>>
      */
-    public function mediaRuleDataProvider()
+    public static function mediaRuleDataProvider()
     {
         return [
             'without spaces around arguments' => ['@media(min-width: 768px){.class{color:red}}'],

--- a/tests/CSSList/DocumentTest.php
+++ b/tests/CSSList/DocumentTest.php
@@ -18,7 +18,7 @@ class DocumentTest extends TestCase
      */
     private $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->subject = new Document();
     }
@@ -50,7 +50,7 @@ class DocumentTest extends TestCase
     /**
      * @return array<string, array<int, array<int, DeclarationBlock>>>
      */
-    public function contentsDataProvider()
+    public static function contentsDataProvider()
     {
         return [
             'empty array' => [[]],

--- a/tests/CSSList/KeyFrameTest.php
+++ b/tests/CSSList/KeyFrameTest.php
@@ -18,7 +18,7 @@ class KeyFrameTest extends TestCase
      */
     protected $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->subject = new KeyFrame();
     }

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -43,7 +43,7 @@ EOT;
      */
     private $oDocument;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->oParser = new Parser(self::TEST_CSS);
         $this->oDocument = $this->oParser->parse();

--- a/tests/RuleSet/DeclarationBlockTest.php
+++ b/tests/RuleSet/DeclarationBlockTest.php
@@ -33,7 +33,7 @@ class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function expandBorderShorthandProvider()
+    public static function expandBorderShorthandProvider()
     {
         return [
             ['body{ border: 2px solid #000 }', 'body {border-width: 2px;border-style: solid;border-color: #000;}'],
@@ -66,7 +66,7 @@ class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function expandFontShorthandProvider()
+    public static function expandFontShorthandProvider()
     {
         return [
             [
@@ -122,7 +122,7 @@ class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function expandBackgroundShorthandProvider()
+    public static function expandBackgroundShorthandProvider()
     {
         return [
             ['body {border: 1px;}', 'body {border: 1px;}'],
@@ -175,7 +175,7 @@ class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function expandDimensionsShorthandProvider()
+    public static function expandDimensionsShorthandProvider()
     {
         return [
             ['body {border: 1px;}', 'body {border: 1px;}'],
@@ -213,7 +213,7 @@ class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function createBorderShorthandProvider()
+    public static function createBorderShorthandProvider()
     {
         return [
             ['body {border-width: 2px;border-style: solid;border-color: #000;}', 'body {border: 2px solid #000;}'],
@@ -244,7 +244,7 @@ class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function createFontShorthandProvider()
+    public static function createFontShorthandProvider()
     {
         return [
             ['body {font-size: 12px; font-family: serif}', 'body {font: 12px serif;}'],
@@ -287,7 +287,7 @@ class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function createDimensionsShorthandProvider()
+    public static function createDimensionsShorthandProvider()
     {
         return [
             ['body {border: 1px;}', 'body {border: 1px;}'],
@@ -325,7 +325,7 @@ class DeclarationBlockTest extends TestCase
     /**
      * @return array<int, array<int, string>>
      */
-    public function createBackgroundShorthandProvider()
+    public static function createBackgroundShorthandProvider()
     {
         return [
             ['body {border: 1px;}', 'body {border: 1px;}'],


### PR DESCRIPTION
Running the test suite was giving me trouble by requiring PHPUnit 5.7, which is quite old. This MR makes the minimal changes necessary to update to 10.2 without modifying the test content in any substantive way.