### PR TITLE
[TASK] Add return types to `setUp()` in tests

### DIFF
--- a/tests/CSSList/DocumentTest.php
+++ b/tests/CSSList/DocumentTest.php
@@ -18,7 +18,7 @@ class DocumentTest extends TestCase
      */
     private $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->subject = new Document();
     }

--- a/tests/CSSList/KeyFrameTest.php
+++ b/tests/CSSList/KeyFrameTest.php
@@ -18,7 +18,7 @@ class KeyFrameTest extends TestCase
      */
     protected $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->subject = new KeyFrame();
     }

--- a/tests/OutputFormatTest.php
+++ b/tests/OutputFormatTest.php
@@ -43,7 +43,7 @@ EOT;
      */
     private $oDocument;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->oParser = new Parser(self::TEST_CSS);
         $this->oDocument = $this->oParser->parse();


### PR DESCRIPTION
This is a blocker for the upgrade to PHPUnit 8.