### PR TITLE
[BUGFIX] Git-ignore the PHPUnit result cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.phive/*
 /.php-cs-fixer.cache
 /.php_cs.cache
+/.phpunit.result.cache
 /composer.lock
 /phpstan.neon
 /vendor/


### PR DESCRIPTION
The corresponding file gets created by more recent versions of PHPUnit.