### PR TITLE
[TASK] Move PHPStan from PHIVE to Composer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Install development tools
         run: |
-          phive --no-progress install --trust-gpg-keys BBAB5DF0A0D6672989CF1869E82B2FB314E9906E,95DE904AB800754A11D80B605E6DDE998AB73B8E,CA7C2C7A30C8E8E1274A847651C67305FFC2E5C0
+          phive --no-progress install --trust-gpg-keys BBAB5DF0A0D6672989CF1869E82B2FB314E9906E,95DE904AB800754A11D80B605E6DDE998AB73B8E
 
       - name: Run Command
         run: composer ci:php:${{ matrix.command }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -3,5 +3,4 @@
   <phar name="php-cs-fixer" version="^3.49.0" installed="3.49.0" location="./.phive/php-cs-fixer.phar" copy="false"/>
   <phar name="phpcbf" version="^3.8.1" installed="3.8.1" location="./.phive/phpcbf.phar" copy="false"/>
   <phar name="phpcs" version="^3.8.1" installed="3.8.1" location="./.phive/phpcs.phar" copy="false"/>
-  <phar name="phpstan" version="^1.10.57" installed="1.10.57" location="./.phive/phpstan.phar" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.36",
-        "codacy/coverage": "^1.4.3"
+        "codacy/coverage": "^1.4.3",
+        "phpstan/phpstan": "^1.10.57"
     },
     "suggest": {
         "ext-mbstring": "for parsing UTF-8 CSS"
@@ -36,6 +37,11 @@
     "autoload": {
         "psr-4": {
             "Sabberworm\\CSS\\": "src/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
         }
     },
     "autoload-dev": {
@@ -54,7 +60,7 @@
         ],
         "ci:php:fixer": "@php ./.phive/php-cs-fixer.phar --config=config/php-cs-fixer.php fix --dry-run -v --show-progress=dots bin src tests",
         "ci:php:sniffer": "@php ./.phive/phpcs.phar --standard=config/phpcs.xml bin src tests",
-        "ci:php:stan": "@php ./.phive/phpstan.phar --configuration=config/phpstan.neon",
+        "ci:php:stan": "phpstan --no-progress --configuration=config/phpstan.neon",
         "ci:static": [
             "@ci:php:fixer",
             "@ci:php:sniffer",


### PR DESCRIPTION
This allows us to have PHPStan extensions, e.g., for PHPUnit.