### PR TITLE
[CLEANUP] Autoformat the code

### DIFF
--- a/src/OutputFormatter.php
+++ b/src/OutputFormatter.php
@@ -215,6 +215,7 @@ class OutputFormatter
     /**
      *
      * @param array<Commentable> $aComments
+     *
      * @return string
      */
     public function comments(Commentable $oCommentable)

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -43,9 +43,9 @@ abstract class Value implements Renderable
         //Build a list of delimiters and parsed values
         while (
             !($oParserState->comes('}') || $oParserState->comes(';') || $oParserState->comes('!')
-            || $oParserState->comes(')')
-            || $oParserState->comes('\\')
-            || $oParserState->isEnd())
+                || $oParserState->comes(')')
+                || $oParserState->comes('\\')
+                || $oParserState->isEnd())
         ) {
             if (count($aStack) > 0) {
                 $bFoundDelimiter = false;

--- a/tests/Comment/CommentTest.php
+++ b/tests/Comment/CommentTest.php
@@ -140,11 +140,11 @@ class CommentTest extends TestCase
 ', $oCss->render(OutputFormat::createPretty()));
         self::assertSame(
             '/** Number 11 **//**' . "\n"
-                . ' * Comments' . "\n"
-                . ' *//* Hell */@import url("some/url.css") screen;'
-                . '/* Number 4 *//* Number 5 */.foo,#bar{'
-                . '/* Number 6 */background-color:#000;}@media screen{'
-                . '/** Number 10 **/#foo.bar{/** Number 10b **/position:absolute;}}',
+            . ' * Comments' . "\n"
+            . ' *//* Hell */@import url("some/url.css") screen;'
+            . '/* Number 4 *//* Number 5 */.foo,#bar{'
+            . '/* Number 6 */background-color:#000;}@media screen{'
+            . '/** Number 10 **/#foo.bar{/** Number 10b **/position:absolute;}}',
             $oCss->render(OutputFormat::createCompact()->setRenderComments(true))
         );
     }
@@ -170,8 +170,8 @@ class CommentTest extends TestCase
 ', $oCss->render(OutputFormat::createPretty()->setRenderComments(false)));
         self::assertSame(
             '@import url("some/url.css") screen;'
-                . '.foo,#bar{background-color:#000;}'
-                . '@media screen{#foo.bar{position:absolute;}}',
+            . '.foo,#bar{background-color:#000;}'
+            . '@media screen{#foo.bar{position:absolute;}}',
             $oCss->render(OutputFormat::createCompact())
         );
     }


### PR DESCRIPTION
Autoformat the code with the default PhpStorm settings (and re-run `composer fix:php` to minimize formatting-related changes when code is changed and autoformatted.