### PR TITLE
[BUGFIX] Prevent accessing an uninitialized variable in `DeclarationB…

### DIFF
--- a/config/phpstan-baseline.neon
+++ b/config/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: ../src/RuleSet/DeclarationBlock.php
 
 		-
-			message: "#^Variable \\$oRule might not be defined\\.$#"
-			count: 2
-			path: ../src/RuleSet/DeclarationBlock.php
-
-		-
 			message: "#^Variable \\$oVal might not be defined\\.$#"
 			count: 1
 			path: ../src/Value/CalcFunction.php

--- a/src/RuleSet/DeclarationBlock.php
+++ b/src/RuleSet/DeclarationBlock.php
@@ -565,6 +565,7 @@ class DeclarationBlock extends RuleSet
     public function createShorthandProperties(array $aProperties, $sShorthand)
     {
         $aRules = $this->getRulesAssoc();
+        $oRule = null;
         $aNewValues = [];
         foreach ($aProperties as $sProperty) {
             if (!isset($aRules[$sProperty])) {
@@ -585,7 +586,7 @@ class DeclarationBlock extends RuleSet
                 $this->removeRule($sProperty);
             }
         }
-        if (count($aNewValues)) {
+        if ($aNewValues !== [] && $oRule instanceof Rule) {
             $oNewRule = new Rule($sShorthand, $oRule->getLineNo(), $oRule->getColNo());
             foreach ($aNewValues as $mValue) {
                 $oNewRule->addValue($mValue);


### PR DESCRIPTION
…lock`